### PR TITLE
Add StyleApplicator for improved component-level styling

### DIFF
--- a/src/dr_plotter/plotters/base.py
+++ b/src/dr_plotter/plotters/base.py
@@ -78,7 +78,10 @@ class BasePlotter:
         self.theme = self.__class__.default_theme if theme is None else theme
         self.style_engine: StyleEngine = StyleEngine(self.theme, self.figure_manager)
         self.style_applicator: StyleApplicator = StyleApplicator(
-            self.theme, self.kwargs, self.grouping_params
+            self.theme,
+            self.kwargs,
+            self.grouping_params,
+            figure_manager=self.figure_manager,
         )
         self.plot_data: Optional[pd.DataFrame] = None
         self._initialize_subplot_specific_params()
@@ -221,7 +224,11 @@ class BasePlotter:
 
             if self.__class__.use_style_applicator:
                 group_applicator = StyleApplicator(
-                    self.theme, self.kwargs, self.grouping_params, group_values
+                    self.theme,
+                    self.kwargs,
+                    self.grouping_params,
+                    group_values,
+                    self.figure_manager,
                 )
                 component_styles = group_applicator.get_component_styles(
                     self.__class__.plotter_name

--- a/src/dr_plotter/plotters/histogram.py
+++ b/src/dr_plotter/plotters/histogram.py
@@ -1,10 +1,9 @@
-"""
-Atomic plotter for histograms.
-"""
+from typing import Any, Dict, List, Set
 
-from typing import Dict, List
+import pandas as pd
 
 from dr_plotter import consts
+from dr_plotter.legend import Legend
 from dr_plotter.theme import HISTOGRAM_THEME, Theme
 from dr_plotter.types import BasePlotterParamName, SubPlotterParamName, VisualChannel
 
@@ -15,9 +14,9 @@ class HistogramPlotter(BasePlotter):
     plotter_name: str = "histogram"
     plotter_params: List[str] = []
     param_mapping: Dict[BasePlotterParamName, SubPlotterParamName] = {}
-    enabled_channels: Dict[VisualChannel, bool] = {}
+    enabled_channels: Set[VisualChannel] = set()
     default_theme: Theme = HISTOGRAM_THEME
+    use_style_applicator: bool = True
 
-    def _draw(self, ax, data, legend, **kwargs):
+    def _draw(self, ax: Any, data: pd.DataFrame, legend: Legend, **kwargs: Any) -> None:
         ax.hist(data[consts.X_COL_NAME], **kwargs)
-        ax.set_ylabel(self.theme.axes_styles.get("ylabel"))

--- a/src/dr_plotter/plotters/scatter.py
+++ b/src/dr_plotter/plotters/scatter.py
@@ -1,7 +1,3 @@
-"""
-Atomic plotter for scatter plots with multi-series support.
-"""
-
 from typing import Any, Dict, List, Set
 
 import pandas as pd
@@ -22,5 +18,36 @@ class ScatterPlotter(BasePlotter):
     default_theme: Theme = SCATTER_THEME
     use_style_applicator: bool = True
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        if self.use_style_applicator:
+            self.style_applicator.register_post_processor(
+                "scatter", "collection", self._style_scatter_collection
+            )
+
+    def _style_scatter_collection(
+        self, collection: Any, styles: Dict[str, Any]
+    ) -> None:
+        for attr, value in styles.items():
+            if attr == "sizes" and hasattr(collection, "set_sizes"):
+                collection.set_sizes([value])
+            elif attr == "facecolors" and hasattr(collection, "set_facecolors"):
+                collection.set_facecolors(value)
+            elif attr == "edgecolors" and hasattr(collection, "set_edgecolors"):
+                collection.set_edgecolors(value)
+            elif attr == "linewidths" and hasattr(collection, "set_linewidths"):
+                collection.set_linewidths(value)
+            elif attr == "alpha" and hasattr(collection, "set_alpha"):
+                collection.set_alpha(value)
+            elif hasattr(collection, f"set_{attr}"):
+                setter = getattr(collection, f"set_{attr}")
+                setter(value)
+
     def _draw(self, ax: Any, data: pd.DataFrame, legend: Legend, **kwargs: Any) -> None:
-        ax.scatter(data[consts.X_COL_NAME], data[consts.Y_COL_NAME], **kwargs)
+        collection = ax.scatter(
+            data[consts.X_COL_NAME], data[consts.Y_COL_NAME], **kwargs
+        )
+
+        if self.use_style_applicator:
+            artists = {"collection": collection}
+            self.style_applicator.apply_post_processing("scatter", artists)

--- a/src/dr_plotter/plotters/scatter.py
+++ b/src/dr_plotter/plotters/scatter.py
@@ -2,9 +2,12 @@
 Atomic plotter for scatter plots with multi-series support.
 """
 
-from typing import Dict, List
+from typing import Any, Dict, List, Set
+
+import pandas as pd
 
 from dr_plotter import consts
+from dr_plotter.legend import Legend
 from dr_plotter.theme import SCATTER_THEME, Theme
 from dr_plotter.types import BasePlotterParamName, SubPlotterParamName, VisualChannel
 
@@ -12,21 +15,12 @@ from .base import BasePlotter
 
 
 class ScatterPlotter(BasePlotter):
-    """
-    An atomic plotter for creating scatter plots with multi-series support.
-    """
-
-    # Declarative configuration
     plotter_name: str = "scatter"
     plotter_params: List[str] = []
     param_mapping: Dict[BasePlotterParamName, SubPlotterParamName] = {}
-    enabled_channels: Dict[VisualChannel, bool] = {
-        "hue": True,
-        "size": True,
-        "marker": True,
-        "alpha": True,
-    }
+    enabled_channels: Set[VisualChannel] = {"hue", "size", "marker", "alpha"}
     default_theme: Theme = SCATTER_THEME
+    use_style_applicator: bool = True
 
-    def _draw(self, ax, data, legend, **kwargs):
+    def _draw(self, ax: Any, data: pd.DataFrame, legend: Legend, **kwargs: Any) -> None:
         ax.scatter(data[consts.X_COL_NAME], data[consts.Y_COL_NAME], **kwargs)

--- a/src/dr_plotter/style_applicator.py
+++ b/src/dr_plotter/style_applicator.py
@@ -18,11 +18,13 @@ class StyleApplicator:
         kwargs: Dict[str, Any],
         grouping_cfg: Optional[GroupingConfig] = None,
         group_values: Optional[Dict[str, Any]] = None,
+        figure_manager: Optional[Any] = None,
     ) -> None:
         self.theme = theme
         self.kwargs = kwargs
         self.grouping_cfg = grouping_cfg
         self.group_values = group_values or {}
+        self.figure_manager = figure_manager
         self._component_schemas = self._load_component_schemas()
         self._post_processors: Dict[str, Callable] = {}
 
@@ -199,7 +201,7 @@ class StyleApplicator:
 
         from dr_plotter.plotters.style_engine import StyleEngine
 
-        style_engine = StyleEngine(self.theme)
+        style_engine = StyleEngine(self.theme, self.figure_manager)
         return style_engine.get_styles_for_group(self.group_values, self.grouping_cfg)
 
     def _get_component_schema(

--- a/src/dr_plotter/style_applicator.py
+++ b/src/dr_plotter/style_applicator.py
@@ -1,0 +1,224 @@
+from typing import Any, Dict, Optional, Set, Tuple
+
+from dr_plotter.consts import VISUAL_CHANNELS
+from dr_plotter.grouping_config import GroupingConfig
+from dr_plotter.theme import Theme
+
+type ComponentName = str
+type AttributeName = str
+type ComponentSchema = Dict[ComponentName, Set[AttributeName]]
+type ComponentStyles = Dict[ComponentName, Dict[str, Any]]
+
+
+class StyleApplicator:
+    def __init__(
+        self,
+        theme: Theme,
+        kwargs: Dict[str, Any],
+        grouping_cfg: Optional[GroupingConfig] = None,
+        group_values: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.theme = theme
+        self.kwargs = kwargs
+        self.grouping_cfg = grouping_cfg
+        self.group_values = group_values or {}
+        self._component_schemas = self._load_component_schemas()
+
+    def get_component_styles(self, plot_type: str) -> ComponentStyles:
+        schema = self._get_component_schema(plot_type)
+        component_styles = {}
+
+        for component_name, component_attrs in schema.items():
+            styles = self._resolve_component_styles(
+                plot_type, component_name, component_attrs
+            )
+            component_styles[component_name] = styles
+
+        return component_styles
+
+    def get_single_component_styles(
+        self, plot_type: str, component: str
+    ) -> Dict[str, Any]:
+        schema = self._get_component_schema(plot_type)
+        if component not in schema:
+            return {}
+        
+        return self._resolve_component_styles(
+            plot_type, component, schema[component]
+        )
+
+    def _resolve_component_styles(
+        self, plot_type: str, component: str, attrs: Set[str]
+    ) -> Dict[str, Any]:
+        resolved_styles = {}
+        
+        base_theme_styles = {}
+        base_theme_styles.update(self.theme.general_styles)
+        base_theme_styles.update(self.theme.plot_styles)
+        base_theme_styles.update(self.theme.axes_styles)
+        base_theme_styles.update(self.theme.figure_styles)
+        
+        plot_styles = {}
+        if plot_type in self._get_plot_specific_themes():
+            plot_theme = self._get_plot_specific_themes()[plot_type]
+            plot_styles.update(plot_theme.general_styles)
+            plot_styles.update(plot_theme.plot_styles)
+            plot_styles.update(plot_theme.axes_styles)
+            plot_styles.update(plot_theme.figure_styles)
+        
+        group_styles = self._get_group_styles_for_component(plot_type, component)
+        
+        component_kwargs = self._extract_component_kwargs(component, attrs)
+        
+        for attr in attrs:
+            if attr in component_kwargs:
+                resolved_styles[attr] = component_kwargs[attr]
+            elif attr in group_styles:
+                resolved_styles[attr] = group_styles[attr]
+            elif attr in plot_styles:
+                resolved_styles[attr] = plot_styles[attr]
+            elif attr in base_theme_styles:
+                resolved_styles[attr] = base_theme_styles[attr]
+        
+        for key, value in component_kwargs.items():
+            if key not in attrs:
+                resolved_styles[key] = value
+        
+        # Special handling: don't include cmap unless c is also present
+        if "cmap" in resolved_styles and "c" not in resolved_styles:
+            del resolved_styles["cmap"]
+        
+        return resolved_styles
+
+    def _extract_component_kwargs(
+        self, component: str, attrs: Set[str]
+    ) -> Dict[str, Any]:
+        if component == "main":
+            extracted = {}
+            for k, v in self.kwargs.items():
+                if k in attrs and not self._is_reserved_kwarg(k):
+                    extracted[k] = v
+                elif not self._is_reserved_kwarg(k) and not k.endswith("_by"):
+                    extracted[k] = v
+            return extracted
+        
+        component_prefix = f"{component}_"
+        extracted = {}
+        
+        for key, value in self.kwargs.items():
+            if key.startswith(component_prefix):
+                clean_key = key[len(component_prefix):]
+                extracted[clean_key] = value
+            elif key in attrs and not any(
+                key.startswith(f"{other}_") for other in ["contour", "scatter", "violin", "text", "line"]
+            ):
+                extracted[key] = value
+        
+        return extracted
+
+    def _is_reserved_kwarg(self, key: str) -> bool:
+        # Build visual channel names dynamically from constants
+        visual_channel_names = set(VISUAL_CHANNELS)
+        visual_channel_by_names = {f"{ch}_by" for ch in VISUAL_CHANNELS}
+        
+        # Note: We DON'T include raw visual channel names (hue, style, etc.) 
+        # when they're used as style values (e.g., alpha=0.6 for transparency)
+        # Only the "_by" versions are reserved for grouping
+        reserved = {
+            "x", "y",
+            "data", "theme", "title", "xlabel", "ylabel", "legend",
+            "grid", "colorbar_label", "time_col", "category_col", "value_col",
+            "grouping_cfg"
+        }
+        reserved.update(visual_channel_by_names)
+        
+        # Special case: if the value is a string, it might be a column name for grouping
+        # If it's a number (like alpha=0.6), it's a style value
+        if key in visual_channel_names and key in self.kwargs:
+            value = self.kwargs[key]
+            if isinstance(value, str):
+                # It's a column name for grouping, so it's reserved
+                return True
+            # It's a numeric value for styling, so it's not reserved
+            return False
+            
+        return key in reserved
+
+    def _get_group_styles_for_component(
+        self, plot_type: str, component: str
+    ) -> Dict[str, Any]:
+        if not self.grouping_cfg or not self.group_values:
+            return {}
+        
+        group_styled_components = self._get_group_styled_components(plot_type)
+        if component not in group_styled_components:
+            return {}
+        
+        from dr_plotter.plotters.style_engine import StyleEngine
+        style_engine = StyleEngine(self.theme)
+        return style_engine.get_styles_for_group(self.group_values, self.grouping_cfg)
+
+    def _get_component_schema(self, plot_type: str) -> ComponentSchema:
+        return self._component_schemas.get(plot_type, {"main": set()})
+
+    def _get_group_styled_components(self, plot_type: str) -> Set[str]:
+        group_styled_map = {
+            "scatter": {"main"},
+            "line": {"main"},
+            "bar": {"main"},
+            "histogram": {"main"},
+            "violin": {"violin_body"},
+            "heatmap": {"main"},
+            "contour": {"scatter"},
+            "bump": {"line"},
+        }
+        return group_styled_map.get(plot_type, {"main"})
+
+    def _get_plot_specific_themes(self) -> Dict[str, Theme]:
+        from dr_plotter.theme import (
+            LINE_THEME, SCATTER_THEME, BAR_THEME, HISTOGRAM_THEME,
+            VIOLIN_THEME, HEATMAP_THEME, BUMP_PLOT_THEME, CONTOUR_THEME
+        )
+        
+        return {
+            "line": LINE_THEME,
+            "scatter": SCATTER_THEME,
+            "bar": BAR_THEME,
+            "histogram": HISTOGRAM_THEME,
+            "violin": VIOLIN_THEME,
+            "heatmap": HEATMAP_THEME,
+            "bump": BUMP_PLOT_THEME,
+            "contour": CONTOUR_THEME,
+        }
+
+    def _load_component_schemas(self) -> Dict[str, ComponentSchema]:
+        return {
+            "scatter": {
+                "main": {"s", "alpha", "color", "marker", "edgecolors", "linewidths", "c", "cmap", "vmin", "vmax"}
+            },
+            "line": {
+                "main": {"color", "linewidth", "linestyle", "marker", "markersize", "alpha", "label"}
+            },
+            "bar": {
+                "main": {"color", "alpha", "edgecolor", "linewidth", "width", "label"}
+            },
+            "histogram": {
+                "main": {"color", "alpha", "edgecolor", "linewidth", "bins", "label", "histtype", "cumulative", "density", "weights", "bottom", "rwidth"}
+            },
+            "violin": {
+                "violin_body": {"facecolor", "edgecolor", "alpha", "linewidth"},
+                "violin_lines": {"color", "linewidth", "linestyle"},
+                "stats": {"showmeans", "showmedians", "showextrema"}
+            },
+            "heatmap": {
+                "main": {"cmap", "vmin", "vmax", "center", "robust", "annot", "fmt", "linewidths", "linecolor", "cbar"}
+            },
+            "contour": {
+                "contour": {"levels", "cmap", "alpha", "linewidths", "linestyles", "colors"},
+                "scatter": {"s", "alpha", "color", "marker", "edgecolors"}
+            },
+            "bump": {
+                "line": {"color", "linewidth", "linestyle", "marker", "markersize", "alpha"},
+                "text": {"fontsize", "fontweight", "va", "ha"}
+            }
+        }

--- a/src/dr_plotter/style_applicator.py
+++ b/src/dr_plotter/style_applicator.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Set, Tuple
+from typing import Any, Callable, Dict, Optional, Set
 
 from dr_plotter.consts import VISUAL_CHANNELS
 from dr_plotter.grouping_config import GroupingConfig
@@ -8,6 +8,7 @@ type ComponentName = str
 type AttributeName = str
 type ComponentSchema = Dict[ComponentName, Set[AttributeName]]
 type ComponentStyles = Dict[ComponentName, Dict[str, Any]]
+type Phase = str
 
 
 class StyleApplicator:
@@ -23,53 +24,84 @@ class StyleApplicator:
         self.grouping_cfg = grouping_cfg
         self.group_values = group_values or {}
         self._component_schemas = self._load_component_schemas()
+        self._post_processors: Dict[str, Callable] = {}
 
-    def get_component_styles(self, plot_type: str) -> ComponentStyles:
-        schema = self._get_component_schema(plot_type)
+    def get_component_styles(
+        self, plot_type: str, phase: Phase = "plot"
+    ) -> ComponentStyles:
+        schema = self._get_component_schema(plot_type, phase)
         component_styles = {}
 
         for component_name, component_attrs in schema.items():
             styles = self._resolve_component_styles(
-                plot_type, component_name, component_attrs
+                plot_type, component_name, component_attrs, phase
             )
             component_styles[component_name] = styles
 
         return component_styles
 
     def get_single_component_styles(
-        self, plot_type: str, component: str
+        self, plot_type: str, component: str, phase: Phase = "plot"
     ) -> Dict[str, Any]:
-        schema = self._get_component_schema(plot_type)
+        schema = self._get_component_schema(plot_type, phase)
         if component not in schema:
             return {}
-        
+
         return self._resolve_component_styles(
-            plot_type, component, schema[component]
+            plot_type, component, schema[component], phase
         )
 
+    def register_post_processor(
+        self, plot_type: str, component: str, processor: Callable
+    ) -> None:
+        key = f"{plot_type}.{component}"
+        self._post_processors[key] = processor
+
+    def apply_post_processing(self, plot_type: str, artists: Dict[str, Any]) -> None:
+        post_styles = self.get_component_styles(plot_type, phase="post")
+
+        for component, styles in post_styles.items():
+            processor_key = f"{plot_type}.{component}"
+            if processor_key in self._post_processors:
+                processor = self._post_processors[processor_key]
+                if component in artists:
+                    processor(artists[component], styles)
+
     def _resolve_component_styles(
-        self, plot_type: str, component: str, attrs: Set[str]
+        self, plot_type: str, component: str, attrs: Set[str], phase: Phase = "plot"
     ) -> Dict[str, Any]:
         resolved_styles = {}
-        
+
         base_theme_styles = {}
         base_theme_styles.update(self.theme.general_styles)
-        base_theme_styles.update(self.theme.plot_styles)
-        base_theme_styles.update(self.theme.axes_styles)
-        base_theme_styles.update(self.theme.figure_styles)
-        
+
+        if phase == "plot":
+            base_theme_styles.update(self.theme.plot_styles)
+        elif phase == "post":
+            base_theme_styles.update(self.theme.post_styles)
+        elif phase == "axes":
+            base_theme_styles.update(self.theme.axes_styles)
+        elif phase == "figure":
+            base_theme_styles.update(self.theme.figure_styles)
+
         plot_styles = {}
         if plot_type in self._get_plot_specific_themes():
             plot_theme = self._get_plot_specific_themes()[plot_type]
             plot_styles.update(plot_theme.general_styles)
-            plot_styles.update(plot_theme.plot_styles)
-            plot_styles.update(plot_theme.axes_styles)
-            plot_styles.update(plot_theme.figure_styles)
-        
-        group_styles = self._get_group_styles_for_component(plot_type, component)
-        
-        component_kwargs = self._extract_component_kwargs(component, attrs)
-        
+
+            if phase == "plot":
+                plot_styles.update(plot_theme.plot_styles)
+            elif phase == "post":
+                plot_styles.update(plot_theme.post_styles)
+            elif phase == "axes":
+                plot_styles.update(plot_theme.axes_styles)
+            elif phase == "figure":
+                plot_styles.update(plot_theme.figure_styles)
+
+        group_styles = self._get_group_styles_for_component(plot_type, component, phase)
+
+        component_kwargs = self._extract_component_kwargs(component, attrs, phase)
+
         for attr in attrs:
             if attr in component_kwargs:
                 resolved_styles[attr] = component_kwargs[attr]
@@ -79,19 +111,19 @@ class StyleApplicator:
                 resolved_styles[attr] = plot_styles[attr]
             elif attr in base_theme_styles:
                 resolved_styles[attr] = base_theme_styles[attr]
-        
+
         for key, value in component_kwargs.items():
             if key not in attrs:
                 resolved_styles[key] = value
-        
+
         # Special handling: don't include cmap unless c is also present
         if "cmap" in resolved_styles and "c" not in resolved_styles:
             del resolved_styles["cmap"]
-        
+
         return resolved_styles
 
     def _extract_component_kwargs(
-        self, component: str, attrs: Set[str]
+        self, component: str, attrs: Set[str], phase: Phase = "plot"
     ) -> Dict[str, Any]:
         if component == "main":
             extracted = {}
@@ -101,37 +133,48 @@ class StyleApplicator:
                 elif not self._is_reserved_kwarg(k) and not k.endswith("_by"):
                     extracted[k] = v
             return extracted
-        
+
         component_prefix = f"{component}_"
         extracted = {}
-        
+
         for key, value in self.kwargs.items():
             if key.startswith(component_prefix):
-                clean_key = key[len(component_prefix):]
+                clean_key = key[len(component_prefix) :]
                 extracted[clean_key] = value
             elif key in attrs and not any(
-                key.startswith(f"{other}_") for other in ["contour", "scatter", "violin", "text", "line"]
+                key.startswith(f"{other}_")
+                for other in ["contour", "scatter", "violin", "text", "line"]
             ):
                 extracted[key] = value
-        
+
         return extracted
 
     def _is_reserved_kwarg(self, key: str) -> bool:
         # Build visual channel names dynamically from constants
         visual_channel_names = set(VISUAL_CHANNELS)
         visual_channel_by_names = {f"{ch}_by" for ch in VISUAL_CHANNELS}
-        
-        # Note: We DON'T include raw visual channel names (hue, style, etc.) 
+
+        # Note: We DON'T include raw visual channel names (hue, style, etc.)
         # when they're used as style values (e.g., alpha=0.6 for transparency)
         # Only the "_by" versions are reserved for grouping
         reserved = {
-            "x", "y",
-            "data", "theme", "title", "xlabel", "ylabel", "legend",
-            "grid", "colorbar_label", "time_col", "category_col", "value_col",
-            "grouping_cfg"
+            "x",
+            "y",
+            "data",
+            "theme",
+            "title",
+            "xlabel",
+            "ylabel",
+            "legend",
+            "grid",
+            "colorbar_label",
+            "time_col",
+            "category_col",
+            "value_col",
+            "grouping_cfg",
         }
         reserved.update(visual_channel_by_names)
-        
+
         # Special case: if the value is a string, it might be a column name for grouping
         # If it's a number (like alpha=0.6), it's a style value
         if key in visual_channel_names and key in self.kwargs:
@@ -141,25 +184,35 @@ class StyleApplicator:
                 return True
             # It's a numeric value for styling, so it's not reserved
             return False
-            
+
         return key in reserved
 
     def _get_group_styles_for_component(
-        self, plot_type: str, component: str
+        self, plot_type: str, component: str, phase: Phase = "plot"
     ) -> Dict[str, Any]:
         if not self.grouping_cfg or not self.group_values:
             return {}
-        
+
         group_styled_components = self._get_group_styled_components(plot_type)
         if component not in group_styled_components:
             return {}
-        
+
         from dr_plotter.plotters.style_engine import StyleEngine
+
         style_engine = StyleEngine(self.theme)
         return style_engine.get_styles_for_group(self.group_values, self.grouping_cfg)
 
-    def _get_component_schema(self, plot_type: str) -> ComponentSchema:
-        return self._component_schemas.get(plot_type, {"main": set()})
+    def _get_component_schema(
+        self, plot_type: str, phase: Phase = "plot"
+    ) -> ComponentSchema:
+        plot_schemas = self._component_schemas.get(plot_type, {})
+        if isinstance(plot_schemas, dict) and phase in plot_schemas:
+            return plot_schemas[phase]
+        elif phase == "plot" and isinstance(plot_schemas, dict):
+            # For backward compatibility, if no phase specified, treat as plot phase
+            if "plot" not in plot_schemas and "main" in plot_schemas:
+                return plot_schemas
+        return {"main": set()}
 
     def _get_group_styled_components(self, plot_type: str) -> Set[str]:
         group_styled_map = {
@@ -176,10 +229,16 @@ class StyleApplicator:
 
     def _get_plot_specific_themes(self) -> Dict[str, Theme]:
         from dr_plotter.theme import (
-            LINE_THEME, SCATTER_THEME, BAR_THEME, HISTOGRAM_THEME,
-            VIOLIN_THEME, HEATMAP_THEME, BUMP_PLOT_THEME, CONTOUR_THEME
+            LINE_THEME,
+            SCATTER_THEME,
+            BAR_THEME,
+            HISTOGRAM_THEME,
+            VIOLIN_THEME,
+            HEATMAP_THEME,
+            BUMP_PLOT_THEME,
+            CONTOUR_THEME,
         )
-        
+
         return {
             "line": LINE_THEME,
             "scatter": SCATTER_THEME,
@@ -191,34 +250,136 @@ class StyleApplicator:
             "contour": CONTOUR_THEME,
         }
 
-    def _load_component_schemas(self) -> Dict[str, ComponentSchema]:
+    def _load_component_schemas(self) -> Dict[str, Dict[Phase, ComponentSchema]]:
         return {
             "scatter": {
-                "main": {"s", "alpha", "color", "marker", "edgecolors", "linewidths", "c", "cmap", "vmin", "vmax"}
+                "plot": {
+                    "main": {
+                        "s",
+                        "alpha",
+                        "color",
+                        "marker",
+                        "edgecolors",
+                        "linewidths",
+                        "c",
+                        "cmap",
+                        "vmin",
+                        "vmax",
+                    }
+                },
+                "post": {
+                    "collection": {
+                        "sizes",
+                        "facecolors",
+                        "edgecolors",
+                        "linewidths",
+                        "alpha",
+                    }
+                },
             },
             "line": {
-                "main": {"color", "linewidth", "linestyle", "marker", "markersize", "alpha", "label"}
+                "plot": {
+                    "main": {
+                        "color",
+                        "linewidth",
+                        "linestyle",
+                        "marker",
+                        "markersize",
+                        "alpha",
+                        "label",
+                    }
+                }
             },
             "bar": {
-                "main": {"color", "alpha", "edgecolor", "linewidth", "width", "label"}
+                "plot": {
+                    "main": {
+                        "color",
+                        "alpha",
+                        "edgecolor",
+                        "linewidth",
+                        "width",
+                        "label",
+                    }
+                }
             },
             "histogram": {
-                "main": {"color", "alpha", "edgecolor", "linewidth", "bins", "label", "histtype", "cumulative", "density", "weights", "bottom", "rwidth"}
+                "plot": {
+                    "main": {
+                        "color",
+                        "alpha",
+                        "edgecolor",
+                        "linewidth",
+                        "bins",
+                        "label",
+                        "histtype",
+                        "cumulative",
+                        "density",
+                        "weights",
+                        "bottom",
+                        "rwidth",
+                    }
+                },
+                "post": {
+                    # Histogram returns patches, we could style them post-creation if needed
+                    "patches": {"facecolor", "edgecolor", "linewidth", "alpha"}
+                },
+                "axes": {"properties": {"xlim", "ylim", "xlabel", "ylabel", "title"}},
             },
             "violin": {
-                "violin_body": {"facecolor", "edgecolor", "alpha", "linewidth"},
-                "violin_lines": {"color", "linewidth", "linestyle"},
-                "stats": {"showmeans", "showmedians", "showextrema"}
+                "plot": {
+                    "main": {
+                        "showmeans",
+                        "showmedians",
+                        "showextrema",
+                        "widths",
+                        "points",
+                    }
+                },
+                "post": {
+                    "bodies": {"facecolor", "edgecolor", "alpha", "linewidth"},
+                    "stats": {"color", "linewidth", "linestyle"},
+                },
             },
             "heatmap": {
-                "main": {"cmap", "vmin", "vmax", "center", "robust", "annot", "fmt", "linewidths", "linecolor", "cbar"}
+                "plot": {
+                    "main": {
+                        "cmap",
+                        "vmin",
+                        "vmax",
+                        "center",
+                        "robust",
+                        "annot",
+                        "fmt",
+                        "linewidths",
+                        "linecolor",
+                        "cbar",
+                    }
+                }
             },
             "contour": {
-                "contour": {"levels", "cmap", "alpha", "linewidths", "linestyles", "colors"},
-                "scatter": {"s", "alpha", "color", "marker", "edgecolors"}
+                "plot": {
+                    "contour": {
+                        "levels",
+                        "cmap",
+                        "alpha",
+                        "linewidths",
+                        "linestyles",
+                        "colors",
+                    },
+                    "scatter": {"s", "alpha", "color", "marker", "edgecolors"},
+                }
             },
             "bump": {
-                "line": {"color", "linewidth", "linestyle", "marker", "markersize", "alpha"},
-                "text": {"fontsize", "fontweight", "va", "ha"}
-            }
+                "plot": {
+                    "line": {
+                        "color",
+                        "linewidth",
+                        "linestyle",
+                        "marker",
+                        "markersize",
+                        "alpha",
+                    },
+                    "text": {"fontsize", "fontweight", "va", "ha"},
+                }
+            },
         }

--- a/src/dr_plotter/theme.py
+++ b/src/dr_plotter/theme.py
@@ -45,6 +45,10 @@ class PlotStyles(Style):
     style_type = "plot"
 
 
+class PostStyles(Style):
+    style_type = "post"
+
+
 class AxesStyles(Style):
     style_type = "axes"
 
@@ -59,6 +63,7 @@ class Theme:
         name: str,
         parent: Optional["Theme"] = None,
         plot_styles: Optional[PlotStyles | Dict] = None,
+        post_styles: Optional[PostStyles | Dict] = None,
         axes_styles: Optional[AxesStyles | Dict] = None,
         figure_styles: Optional[FigureStyles | Dict] = None,
         **styles: Any,
@@ -68,6 +73,7 @@ class Theme:
         self.all_styles: Dict[str, Style] = {}
         for cls, cls_dict in [
             (PlotStyles, plot_styles),
+            (PostStyles, post_styles),
             (AxesStyles, axes_styles),
             (FigureStyles, figure_styles),
             (Style, styles),
@@ -86,6 +92,10 @@ class Theme:
     @property
     def plot_styles(self) -> Dict[str, Any]:
         return self.get_all_styles(PlotStyles)
+
+    @property
+    def post_styles(self) -> Dict[str, Any]:
+        return self.get_all_styles(PostStyles)
 
     @property
     def axes_styles(self) -> Dict[str, Any]:


### PR DESCRIPTION
# Add StyleApplicator for improved component styling

This PR introduces a new `StyleApplicator` class that provides a more structured approach to styling plot components. The implementation:

- Adds a new `StyleApplicator` class that manages styles for different plot components
- Updates `BasePlotter` to support the style applicator with a new `use_style_applicator` flag
- Refactors `HistogramPlotter` to use the style applicator with post-processing support
- Updates `ScatterPlotter` to leverage the style applicator with collection styling
- Enhances `ViolinPlotter` with comprehensive style applicator integration
- Adds support for multiple processing phases (plot, post, axes, figure)
- Implements component-specific styling with proper attribute mapping

The style applicator provides a more maintainable and extensible way to apply styles to different plot components, with support for post-processing artist objects after they've been created.