### PR TITLE
Add DataDecide integration for training curve examples

### DIFF
--- a/examples/06b_faceted_training_curves_themed.py
+++ b/examples/06b_faceted_training_curves_themed.py
@@ -1,42 +1,42 @@
+"""
+Themed Faceted Training Curves Example
+
+Requires DataDecide integration:
+    uv add "dr_plotter[datadec]"
+
+This example demonstrates advanced themed faceted plotting with real ML training data.
+"""
+
 from typing import List, Tuple
 import argparse
 import itertools
+import sys
 import pandas as pd
 import matplotlib.pyplot as plt
 from dr_plotter.figure import FigureManager
 from dr_plotter.figure_config import FigureConfig
 from dr_plotter.legend_manager import LegendConfig, LegendStrategy
 from dr_plotter.theme import Theme, PlotStyles, AxesStyles, FigureStyles, BASE_THEME
+from dr_plotter.scripting.datadec_utils import get_clean_datadec_df, validate_cli_params, validate_cli_data
 
 
 def load_and_prepare_data() -> pd.DataFrame:
-    return pd.read_parquet("data/mean_eval.parquet")
+    """Load clean, pre-validated data from DataDecide."""
+    try:
+        return get_clean_datadec_df(filter_types=["ppl", "max_steps"])
+    except ImportError as e:
+        print(f"Error: {e}")
+        sys.exit(1)
 
 
-def create_model_size_ordering() -> List[str]:
-    size_order = [
-        "4M",
-        "6M",
-        "8M",
-        "10M",
-        "14M",
-        "16M",
-        "20M",
-        "60M",
-        "90M",
-        "150M",
-        "300M",
-        "530M",
-        "750M",
-        "1B",
-    ]
-    return size_order
 
 
 def create_faceted_training_curves_theme(
-    x_log: bool = False, y_log: bool = False
+    x_log: bool = False, y_log: bool = False, model_sizes: List[str] = None
 ) -> Theme:
-    model_sizes = create_model_size_ordering()
+    if model_sizes is None:
+        # Default model sizes - will be overridden by actual data
+        model_sizes = ["4M", "6M", "8M", "10M", "14M", "16M", "20M", "60M", "90M", "150M", "300M", "530M", "750M", "1B"]
 
     color_palette = [
         "#1f77b4",
@@ -85,21 +85,16 @@ def create_faceted_training_curves_theme(
 def subset_data_for_plotting(
     df: pd.DataFrame, target_recipes: List[str], model_sizes: List[str]
 ) -> pd.DataFrame:
+    """Filter DataFrame for target metrics, recipes, and model sizes."""
     target_metrics = ["pile-valppl", "mmlu_average_correct_prob"]
 
-    assert all(metric in df.columns for metric in target_metrics), (
-        f"Missing metrics from {target_metrics}"
-    )
-    assert all(recipe in df["data"].values for recipe in target_recipes), (
-        f"Missing recipes from {target_recipes}"
-    )
-
-    filtered_df = df[df["data"].isin(target_recipes)].copy()
-    filtered_df = filtered_df[filtered_df["params"].isin(model_sizes)].copy()
-
+    # DataDecide guarantees these columns exist, but filter for what we need
+    filtered_df = df[df["data"].isin(target_recipes) & df["params"].isin(model_sizes)].copy()
+    
     keep_columns = ["params", "data", "step"] + target_metrics
     filtered_df = filtered_df[keep_columns].copy()
-
+    
+    # Set up categorical ordering for consistent plotting
     filtered_df["params"] = pd.Categorical(
         filtered_df["params"], categories=model_sizes, ordered=True
     )
@@ -107,7 +102,7 @@ def subset_data_for_plotting(
         filtered_df["data"], categories=target_recipes, ordered=True
     )
     filtered_df = filtered_df.sort_values(["params", "data", "step"])
-
+    
     return filtered_df
 
 
@@ -154,14 +149,13 @@ def plot_training_curves_themed(
 
         for col_idx, recipe in enumerate(target_recipes):
             recipe_data = df[df["data"] == recipe].copy()
-            assert len(recipe_data) > 0, f"No data found for recipe: {recipe}"
 
             for row_idx, (metric, metric_label) in enumerate(
                 zip(metrics, metric_labels)
             ):
+                # DataDecide provides clean data, minimal processing needed
                 metric_data = recipe_data[["params", "step", metric]].copy()
-                metric_data = metric_data.dropna()
-
+                
                 if len(metric_data) == 0:
                     continue
 
@@ -234,23 +228,8 @@ def create_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--model-sizes",
         nargs="+",
-        default=[
-            "4M",
-            "6M",
-            "8M",
-            "10M",
-            "14M",
-            "16M",
-            "20M",
-            "60M",
-            "90M",
-            "150M",
-            "300M",
-            "530M",
-            "750M",
-            "1B",
-        ],
-        help="Model sizes to include (in order for line styling)",
+        default=["all"],
+        help="Model sizes to include (in order for line styling). Use 'all' for all available.",
     )
 
     # Axis limits
@@ -271,13 +250,21 @@ def main() -> None:
     print("Loading and preparing data...")
     df = load_and_prepare_data()
     print(f"Loaded {len(df):,} rows")
+    
+    # Validate CLI arguments using DataDecide utilities
+    try:
+        validated_recipes = validate_cli_data(args.recipes)
+        validated_model_sizes = validate_cli_params(args.model_sizes)
+    except ImportError as e:
+        print(f"Error: {e}")
+        sys.exit(1)
 
     print("Filtering data for target metrics, recipes, and model sizes...")
-    filtered_df = subset_data_for_plotting(df, args.recipes, args.model_sizes)
+    filtered_df = subset_data_for_plotting(df, validated_recipes, validated_model_sizes)
     print(f"Filtered to {len(filtered_df):,} rows")
 
-    print(f"Model sizes (in order): {args.model_sizes}")
-    print(f"Data recipes (in order): {args.recipes}")
+    print(f"Model sizes (in order): {validated_model_sizes}")
+    print(f"Data recipes (in order): {validated_recipes}")
 
     config_info = []
     if args.x_log:
@@ -292,7 +279,7 @@ def main() -> None:
 
     print(f"Creating custom theme with {config_desc}...")
     custom_theme = create_faceted_training_curves_theme(
-        x_log=args.x_log, y_log=args.y_log
+        x_log=args.x_log, y_log=args.y_log, model_sizes=validated_model_sizes
     )
     print(f"Theme created: {custom_theme.name}")
     print(f"Theme plot styles: {custom_theme.plot_styles}")
@@ -307,7 +294,7 @@ def main() -> None:
     )
     plot_training_curves_themed(
         filtered_df,
-        args.recipes,
+        validated_recipes,
         x_log=args.x_log,
         y_log=args.y_log,
         xlim=args.xlim,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[project.optional-dependencies]
+datadec = ["datadec"]
+
 [dependency-groups]
 dev = [
     "pytest>=8.4.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project.optional-dependencies]
-datadec = ["datadec"]
+datadec = ["datadec @ git+https://github.com/drothermel/datadec.git"]
 
 [dependency-groups]
 dev = [

--- a/src/dr_plotter/scripting/datadec_utils.py
+++ b/src/dr_plotter/scripting/datadec_utils.py
@@ -1,0 +1,44 @@
+"""Utilities for DataDecide integration (optional dependency)."""
+
+from typing import Tuple, Any, List
+
+
+def check_datadec_available() -> bool:
+    """Check if DataDecide is available and provide helpful error."""
+    try:
+        import datadec  # noqa: F401
+        return True
+    except ImportError:
+        raise ImportError(
+            "DataDecide integration requires the 'datadec' optional dependency.\n"
+            "Install with: uv add 'dr_plotter[datadec]' or pip install 'dr_plotter[datadec]'"
+        ) from None
+
+
+def safe_import_datadec() -> Tuple[Any, Any, Any]:
+    """Import DataDecide with helpful error if not available."""
+    check_datadec_available()
+    from datadec import DataDecide
+    from datadec.script_utils import select_params, select_data
+    return DataDecide, select_params, select_data
+
+
+def validate_cli_params(
+    param_args: List[str], exclude_params: List[str] = None
+) -> List[str]:
+    """Validate model parameter arguments using DataDecide utilities."""
+    _, select_params, _ = safe_import_datadec()
+    return select_params(param_args, exclude=exclude_params or [])
+
+
+def validate_cli_data(data_args: List[str]) -> List[str]:
+    """Validate data recipe arguments using DataDecide utilities."""
+    _, _, select_data = safe_import_datadec()
+    return select_data(data_args)
+
+
+def get_clean_datadec_df(filter_types: List[str] = None, **kwargs):
+    """Get clean, pre-filtered DataFrame from DataDecide."""
+    DataDecide, _, _ = safe_import_datadec()
+    dd = DataDecide(**kwargs)
+    return dd.get_filtered_df(filter_types=filter_types or ["ppl", "max_steps"])


### PR DESCRIPTION
### TL;DR

Added DataDecide integration to the plotting examples and scripts, making it easier to work with ML training data.

### What changed?

- Added optional `datadec` dependency in `pyproject.toml`
- Created a new utility module `dr_plotter.scripting.datadec_utils` with helper functions for DataDecide integration
- Updated examples (06_faceted_training_curves.py and 06b_faceted_training_curves_themed.py) to use DataDecide for data loading
- Improved scripts (explore_mean_eval_data.py and plot_metric_scaling.py) with DataDecide integration
- Added docstrings to all examples and scripts explaining DataDecide requirements
- Simplified data loading and validation by leveraging DataDecide's utilities
- Changed default model size argument to use "all" instead of hardcoded list

### How to test?

1. Install the optional DataDecide dependency:
   ```
   uv add "dr_plotter[datadec]"
   ```

2. Run the updated examples:
   ```
   python examples/06_faceted_training_curves.py
   python examples/06b_faceted_training_curves_themed.py
   ```

3. Try the improved scripts:
   ```
   python scripts/explore_mean_eval_data.py
   python scripts/plot_metric_scaling.py pile-valppl
   ```

### Why make this change?

This change improves the user experience by:
- Eliminating the need for local data files by using DataDecide's data access
- Providing better error handling with helpful messages when dependencies are missing
- Simplifying data validation and preprocessing with DataDecide's utilities
- Making examples more robust with pre-validated, clean data
- Improving documentation with clear instructions on requirements