### PR TITLE
Enable direct references in hatch metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [project.optional-dependencies]
 datadec = ["datadec @ git+https://github.com/drothermel/datadec.git"]
 


### PR DESCRIPTION
### TL;DR

Added `allow-direct-references = true` to the Hatch metadata configuration in pyproject.toml.

### What changed?

Added a new section `[tool.hatch.metadata]` with the setting `allow-direct-references = true` to the project configuration file. This enables the use of direct references in the project dependencies.

### How to test?

1. Verify that the project builds correctly with `hatch build`
2. Confirm that direct references (like the git repository reference in the optional dependencies) work properly
3. Check that package installation succeeds with `pip install .`

### Why make this change?

This change explicitly enables direct references in the project metadata, which is necessary for the package to properly handle the git repository reference in the optional dependencies section. Without this setting, newer versions of packaging tools might reject or warn about the direct reference to the GitHub repository in the datadec optional dependency.