### PR TITLE
Add MI_lines.py example and update datadec_utils with tokens column

### DIFF
--- a/examples/29_faceted_plotting_guide.py
+++ b/examples/29_faceted_plotting_guide.py
@@ -169,7 +169,8 @@ def example_4_targeted_plotting() -> None:
             & (data["dataset"] == data["dataset"].unique()[1])  # Col 1 (second dataset)
         ]
 
-        # Use target_row and target_col to place the highlighted data at specific positions
+        # Use target_row and target_col to place the highlighted data at
+        # specific positions
         fm.plot_faceted(
             data=highlight_data,
             plot_type="line",

--- a/examples/MI_lines.py
+++ b/examples/MI_lines.py
@@ -1,0 +1,276 @@
+from typing import Any
+
+from plot_data import ExampleData
+
+from dr_plotter import consts
+from dr_plotter.configs import PlotConfig
+from dr_plotter.figure_manager import FigureManager
+from dr_plotter.scripting.utils import setup_arg_parser, show_or_save_plot
+from dr_plotter.scripting.datadec_utils import get_datadec_functions, prepare_plot_data
+
+DataDecide, select_params, select_data = get_datadec_functions()
+
+def normalize_df(df, params, data):
+    # For each (params, data) group, get the row with the minimum tokens (and all columns)
+    idx_min = df.groupby(["params", "data"])["tokens"].idxmin()
+    idx_max = df.groupby(["params", "data"])["tokens"].idxmax()
+    df_pd_min = df.loc[idx_min].reset_index(drop=True).rename(
+        columns={"tokens": "min_tokens", "value": "min_step_value", "step": "min_step"},
+    )
+    df_pd_max = df.loc[idx_max].reset_index(drop=True).rename(
+        columns={"tokens": "max_tokens", "value": "max_step_value", "step": "max_step"},
+    )
+    df = df.merge(df_pd_min, on=["params", "data"], how="left")
+    df = df.merge(df_pd_max, on=["params", "data"], how="left")
+    df["normed_value"] = df["value"] / df["min_step_value"]
+    df["normed_centered_value"] = 1 - (df["value"] / df["min_step_value"])
+    df["normed_x"] = df["tokens"] / df["max_tokens"]
+    return df
+
+
+
+
+def main(args: Any) -> Any:
+
+    dd = DataDecide()
+    for c in dd.full_eval.columns:
+        print(c)
+    params = select_params(["20M", "60M", "90M", "530M"])
+    data = select_data("Dolma1.7")
+    metric = 'pile-valppl'
+    metrics = [metric]
+    df = prepare_plot_data(dd, params, data, metrics, aggregate_seeds=True)
+    df = normalize_df(df, params, data)
+    print(df.head())
+
+    y_val = "normed_centered_value"
+
+    with FigureManager(
+        PlotConfig(layout={"rows": 2, "cols": 4, "figsize": (16, 10), "tight_layout_pad": 1.0})
+    ) as fm:
+        fm.fig.suptitle(f"{metric} for {data}", fontsize=16)
+        # Multiple lines with hue
+        fm.plot(
+            "line",
+            0,
+            0,
+            df,
+            x="tokens",
+            y=y_val,
+            hue_by="params",
+            title=f"lin-lin x=tokens",
+            xlabel="Tokens",
+            ylabel="PPL",
+        )
+        fm.plot(
+            "line",
+            0,
+            1,
+            df,
+            x="tokens",
+            y=y_val,
+            hue_by="params",
+            title=f"lin-log x=tokens",
+            xlabel="Tokens",
+            ylabel="PPL (log scale)",
+        )
+        fm.plot(
+            "line",
+            0,
+            2,
+            df,
+            x="tokens",
+            y=y_val,
+            hue_by="params",
+            title=f"log-lin x=tokens",
+            xlabel="Tokens (log scale)",
+            ylabel="PPL",
+        )
+        fm.plot(
+            "line",
+            0,
+            3,
+            df,
+            x="tokens",
+            y=y_val,
+            hue_by="params",
+            title=f"log-log x=tokens",
+            xlabel="Tokens (log scale)",
+            ylabel="PPL (log scale)",
+        )
+        #fm.get_axes(0, 0).set_xscale("log")
+        #fm.get_axes(0, 0).set_yscale("log")
+
+        #fm.get_axes(0, 1).set_xscale("log")
+        fm.get_axes(0, 1).set_yscale("log")
+
+        fm.get_axes(0, 2).set_xscale("log")
+        #fm.get_axes(0, 2).set_yscale("log")
+
+        fm.get_axes(0, 3).set_xscale("log")
+        fm.get_axes(0, 3).set_yscale("log")
+        #fm.get_axes(0, 1).set_ylim(0, 1)
+        #fm.get_axes(0, 2).set_ylim(0, 1)
+        """
+        fm.plot(
+            "line",
+            0,
+            0,
+            df,
+            x="tokens",
+            y="value",
+            hue_by="params",
+            title=f"{metric} for {data}",
+            xlabel="Tokens (log scale)",
+            ylabel="PPL",
+        )
+        fm.plot(
+            "line",
+            0,
+            1,
+            df,
+            x="tokens",
+            y="normed_centered_value",
+            hue_by="params",
+            title=f"{metric} for {data}",
+            xlabel="Tokens (log scale)",
+            ylabel="PPL (normalized centered)",
+        )
+        fm.plot(
+            "line",
+            0,
+            2,
+            df,
+            x="tokens",
+            y="normed_centered_value",
+            hue_by="params",
+            title=f"{metric} for {data}",
+            xlabel="Tokens (log scale)",
+            ylabel="PPL (normalized centered, log scale)",
+        )
+        fm.get_axes(0, 0).set_xscale("log")
+        fm.get_axes(0, 1).set_xscale("log")
+        fm.get_axes(0, 2).set_xscale("log")
+        fm.get_axes(0, 2).set_yscale("log")
+        fm.get_axes(0, 1).set_ylim(0, 1)
+        fm.get_axes(0, 2).set_ylim(0, 1)
+        """
+        #fm.get_axes(0, 1).set_xscale("log")
+        #fm.get_axes(0, 2).set_xscale("log")
+        fm.plot(
+            "line",
+            1,
+            0,
+            df,
+            x="normed_x",
+            y=y_val,
+            hue_by="params",
+            title=f"lin-lin x=% training",
+            xlabel="% of training tokens",
+            ylabel="PPL",
+        )
+        fm.plot(
+            "line",
+            1,
+            1,
+            df,
+            x="normed_x",
+            y=y_val,
+            hue_by="params",
+            title=f"lin-log x=% training",
+            xlabel="% of training tokens",
+            ylabel="PPL (log scale)",
+        )
+        fm.plot(
+            "line",
+            1,
+            2,
+            df,
+            x="normed_x",
+            y=y_val,
+            hue_by="params",
+            title=f"log-lin x=% training",
+            xlabel="% of training tokens (log scale)",
+            ylabel="PPL",
+        )
+        fm.plot(
+            "line",
+            1,
+            3,
+            df,
+            x="normed_x",
+            y=y_val,
+            hue_by="params",
+            title=f"log-log x=% training",
+            xlabel="% of training tokens (log scale)",
+            ylabel="PPL (log scale)",
+        )
+        #fm.get_axes(1, 0).set_yscale("log")
+        #fm.get_axes(1, 0).set_xscale("log")
+
+        #fm.get_axes(1, 1).set_xscale("log")
+        fm.get_axes(1, 1).set_yscale("log")
+
+        fm.get_axes(1, 2).set_xscale("log")
+        #fm.get_axes(1, 2).set_yscale("log")
+
+        fm.get_axes(1, 3).set_yscale("log")
+        fm.get_axes(1, 3).set_xscale("log")
+
+        #fm.get_axes(1, 1).set_ylim(0, 1)
+        #fm.get_axes(1, 2).set_ylim(0, 1)
+        """
+        fm.plot(
+            "line",
+            1,
+            0,
+            df,
+            x="normed_x",
+            y="value",
+            hue_by="params",
+            title=f"{metric} for {data}",
+            xlabel="% of training tokens (log scale)",
+            ylabel="PPL (log scale)",
+        )
+        fm.plot(
+            "line",
+            1,
+            1,
+            df,
+            x="normed_x",
+            y="normed_centered_value",
+            hue_by="params",
+            title=f"{metric} for {data}",
+            xlabel="% of training tokens",
+            ylabel="PPL (normalized centered)",
+        )
+        fm.plot(
+            "line",
+            1,
+            2,
+            df,
+            x="normed_x",
+            y="normed_centered_value",
+            hue_by="params",
+            title=f"{metric} for {data}",
+            xlabel="% of training tokens (log scale)",
+            ylabel="PPL (normalized centered (log scale))",
+        )
+        fm.get_axes(1, 0).set_yscale("log")
+        fm.get_axes(1, 0).set_xscale("log")
+        fm.get_axes(1, 2).set_yscale("log")
+        fm.get_axes(1, 2).set_xscale("log")
+        #fm.get_axes(1, 1).set_xscale("log")
+        #fm.get_axes(1, 2).set_xscale("log")
+        fm.get_axes(1, 1).set_ylim(0, 1)
+        fm.get_axes(1, 2).set_ylim(0, 1)
+        """
+
+    show_or_save_plot(fm.fig, args, "10_line_showcase")
+    return fm.fig
+
+
+if __name__ == "__main__":
+    parser = setup_arg_parser(description="Line Plot Showcase")
+    args = parser.parse_args()
+    main(args)

--- a/examples/MI_lines.py
+++ b/examples/MI_lines.py
@@ -1,8 +1,6 @@
 from typing import Any
 
-from plot_data import ExampleData
-
-from dr_plotter import consts
+import pandas as pd
 from dr_plotter.configs import PlotConfig
 from dr_plotter.figure_manager import FigureManager
 from dr_plotter.scripting.utils import setup_arg_parser, show_or_save_plot
@@ -10,15 +8,33 @@ from dr_plotter.scripting.datadec_utils import get_datadec_functions, prepare_pl
 
 DataDecide, select_params, select_data = get_datadec_functions()
 
-def normalize_df(df, params, data):
-    # For each (params, data) group, get the row with the minimum tokens (and all columns)
+
+def normalize_df(df: pd.DataFrame, params: list[str], data: list[str]) -> pd.DataFrame:
+    # For each (params, data) group, get the row with the minimum tokens
+    # (and all columns)
     idx_min = df.groupby(["params", "data"])["tokens"].idxmin()
     idx_max = df.groupby(["params", "data"])["tokens"].idxmax()
-    df_pd_min = df.loc[idx_min].reset_index(drop=True).rename(
-        columns={"tokens": "min_tokens", "value": "min_step_value", "step": "min_step"},
+    df_pd_min = (
+        df.loc[idx_min]
+        .reset_index(drop=True)
+        .rename(
+            columns={
+                "tokens": "min_tokens",
+                "value": "min_step_value",
+                "step": "min_step",
+            },
+        )
     )
-    df_pd_max = df.loc[idx_max].reset_index(drop=True).rename(
-        columns={"tokens": "max_tokens", "value": "max_step_value", "step": "max_step"},
+    df_pd_max = (
+        df.loc[idx_max]
+        .reset_index(drop=True)
+        .rename(
+            columns={
+                "tokens": "max_tokens",
+                "value": "max_step_value",
+                "step": "max_step",
+            },
+        )
     )
     df = df.merge(df_pd_min, on=["params", "data"], how="left")
     df = df.merge(df_pd_max, on=["params", "data"], how="left")
@@ -28,16 +44,13 @@ def normalize_df(df, params, data):
     return df
 
 
-
-
 def main(args: Any) -> Any:
-
     dd = DataDecide()
     for c in dd.full_eval.columns:
         print(c)
     params = select_params(["20M", "60M", "90M", "530M"])
     data = select_data("Dolma1.7")
-    metric = 'pile-valppl'
+    metric = "pile-valppl"
     metrics = [metric]
     df = prepare_plot_data(dd, params, data, metrics, aggregate_seeds=True)
     df = normalize_df(df, params, data)
@@ -46,7 +59,9 @@ def main(args: Any) -> Any:
     y_val = "normed_centered_value"
 
     with FigureManager(
-        PlotConfig(layout={"rows": 2, "cols": 4, "figsize": (16, 10), "tight_layout_pad": 1.0})
+        PlotConfig(
+            layout={"rows": 2, "cols": 4, "figsize": (16, 10), "tight_layout_pad": 1.0}
+        )
     ) as fm:
         fm.fig.suptitle(f"{metric} for {data}", fontsize=16)
         # Multiple lines with hue
@@ -58,7 +73,7 @@ def main(args: Any) -> Any:
             x="tokens",
             y=y_val,
             hue_by="params",
-            title=f"lin-lin x=tokens",
+            title="lin-lin x=tokens",
             xlabel="Tokens",
             ylabel="PPL",
         )
@@ -70,7 +85,7 @@ def main(args: Any) -> Any:
             x="tokens",
             y=y_val,
             hue_by="params",
-            title=f"lin-log x=tokens",
+            title="lin-log x=tokens",
             xlabel="Tokens",
             ylabel="PPL (log scale)",
         )
@@ -82,7 +97,7 @@ def main(args: Any) -> Any:
             x="tokens",
             y=y_val,
             hue_by="params",
-            title=f"log-lin x=tokens",
+            title="log-lin x=tokens",
             xlabel="Tokens (log scale)",
             ylabel="PPL",
         )
@@ -94,23 +109,23 @@ def main(args: Any) -> Any:
             x="tokens",
             y=y_val,
             hue_by="params",
-            title=f"log-log x=tokens",
+            title="log-log x=tokens",
             xlabel="Tokens (log scale)",
             ylabel="PPL (log scale)",
         )
-        #fm.get_axes(0, 0).set_xscale("log")
-        #fm.get_axes(0, 0).set_yscale("log")
+        # fm.get_axes(0, 0).set_xscale("log")
+        # fm.get_axes(0, 0).set_yscale("log")
 
-        #fm.get_axes(0, 1).set_xscale("log")
+        # fm.get_axes(0, 1).set_xscale("log")
         fm.get_axes(0, 1).set_yscale("log")
 
         fm.get_axes(0, 2).set_xscale("log")
-        #fm.get_axes(0, 2).set_yscale("log")
+        # fm.get_axes(0, 2).set_yscale("log")
 
         fm.get_axes(0, 3).set_xscale("log")
         fm.get_axes(0, 3).set_yscale("log")
-        #fm.get_axes(0, 1).set_ylim(0, 1)
-        #fm.get_axes(0, 2).set_ylim(0, 1)
+        # fm.get_axes(0, 1).set_ylim(0, 1)
+        # fm.get_axes(0, 2).set_ylim(0, 1)
         """
         fm.plot(
             "line",
@@ -155,8 +170,8 @@ def main(args: Any) -> Any:
         fm.get_axes(0, 1).set_ylim(0, 1)
         fm.get_axes(0, 2).set_ylim(0, 1)
         """
-        #fm.get_axes(0, 1).set_xscale("log")
-        #fm.get_axes(0, 2).set_xscale("log")
+        # fm.get_axes(0, 1).set_xscale("log")
+        # fm.get_axes(0, 2).set_xscale("log")
         fm.plot(
             "line",
             1,
@@ -165,7 +180,7 @@ def main(args: Any) -> Any:
             x="normed_x",
             y=y_val,
             hue_by="params",
-            title=f"lin-lin x=% training",
+            title="lin-lin x=% training",
             xlabel="% of training tokens",
             ylabel="PPL",
         )
@@ -177,7 +192,7 @@ def main(args: Any) -> Any:
             x="normed_x",
             y=y_val,
             hue_by="params",
-            title=f"lin-log x=% training",
+            title="lin-log x=% training",
             xlabel="% of training tokens",
             ylabel="PPL (log scale)",
         )
@@ -189,7 +204,7 @@ def main(args: Any) -> Any:
             x="normed_x",
             y=y_val,
             hue_by="params",
-            title=f"log-lin x=% training",
+            title="log-lin x=% training",
             xlabel="% of training tokens (log scale)",
             ylabel="PPL",
         )
@@ -201,24 +216,24 @@ def main(args: Any) -> Any:
             x="normed_x",
             y=y_val,
             hue_by="params",
-            title=f"log-log x=% training",
+            title="log-log x=% training",
             xlabel="% of training tokens (log scale)",
             ylabel="PPL (log scale)",
         )
-        #fm.get_axes(1, 0).set_yscale("log")
-        #fm.get_axes(1, 0).set_xscale("log")
+        # fm.get_axes(1, 0).set_yscale("log")
+        # fm.get_axes(1, 0).set_xscale("log")
 
-        #fm.get_axes(1, 1).set_xscale("log")
+        # fm.get_axes(1, 1).set_xscale("log")
         fm.get_axes(1, 1).set_yscale("log")
 
         fm.get_axes(1, 2).set_xscale("log")
-        #fm.get_axes(1, 2).set_yscale("log")
+        # fm.get_axes(1, 2).set_yscale("log")
 
         fm.get_axes(1, 3).set_yscale("log")
         fm.get_axes(1, 3).set_xscale("log")
 
-        #fm.get_axes(1, 1).set_ylim(0, 1)
-        #fm.get_axes(1, 2).set_ylim(0, 1)
+        # fm.get_axes(1, 1).set_ylim(0, 1)
+        # fm.get_axes(1, 2).set_ylim(0, 1)
         """
         fm.plot(
             "line",

--- a/scripts/plot_bump.py
+++ b/scripts/plot_bump.py
@@ -107,7 +107,8 @@ def numerical_sort_key(param_size: str) -> float:
 def add_left_ranking_labels(ax: plt.Axes, bump_data: pd.DataFrame) -> None:
     """Add recipe name labels on the left side showing initial rankings."""
 
-    # Get first time point data for initial rankings (sort numerically, not alphabetically)
+    # Get first time point data for initial rankings
+    # (sort numerically, not alphabetically)
     time_points = sorted(bump_data["time"].unique(), key=numerical_sort_key)
     first_time = time_points[0]
     first_time_data = bump_data[bump_data["time"] == first_time].copy()
@@ -167,7 +168,8 @@ def add_right_ranking_labels(ax: plt.Axes, bump_data: pd.DataFrame) -> None:
 
 
 def add_value_annotations(ax: plt.Axes, bump_data: pd.DataFrame) -> None:
-    # Create mapping from model size names to numeric positions for x-axis (sorted numerically)
+    # Create mapping from model size names to numeric positions for x-axis
+    # (sorted numerically)
     time_points = sorted(bump_data["time"].unique(), key=numerical_sort_key)
     time_to_x = {time_point: idx for idx, time_point in enumerate(time_points)}
 
@@ -229,7 +231,13 @@ def create_arg_parser() -> argparse.ArgumentParser:
         "--data",
         nargs="+",
         default=["all"],
-        help="Data recipes: 'all', 'base', 'base_qc', 'no_ablations', or specific names. Named groups: 'core_datasets', 'dolma17_variants', 'dclm_variants', 'falcon_cc_variants', 'fineweb_variants', 'mix_with_baselines', 'best_ppl', 'good_ppl', 'medium_ppl', 'poor_ppl', 'best_olmes', 'good_olmes', 'medium_olmes', 'poor_olmes'",
+        help=(
+            "Data recipes: 'all', 'base', 'base_qc', 'no_ablations', or names. "
+            "Named groups: 'core_datasets', 'dolma17_variants', 'dclm_variants', "
+            "'falcon_cc_variants', 'fineweb_variants', 'mix_with_baselines', "
+            "'best_ppl', 'good_ppl', 'medium_ppl', 'poor_ppl', 'best_olmes', "
+            "'good_olmes', 'medium_olmes', 'poor_olmes'"
+        ),
     )
 
     parser.add_argument(
@@ -302,7 +310,9 @@ def resolve_data_groups(data_args: list[str]) -> list[str]:
     return list(dict.fromkeys(resolved_recipes))
 
 
-def plot_bump(
+# TODO: Refactor this function - it has grown too large (85 statements)
+# Consider breaking into smaller functions for data preparation, plotting, and output
+def plot_bump(  # noqa: PLR0915
     metric: str = "pile-valppl",
     params: list[str] | None = None,
     data: list[str] | None = None,
@@ -410,7 +420,8 @@ def plot_bump(
     print("\nFirst time rankings (LEFT labels):")
     for _, row in first_data.iterrows():
         print(
-            f"  Rank {row['rank']}: {row['category']} (ppl={row['original_ppl']:.2f}, score={row['score']:.2f})"
+            f"  Rank {row['rank']}: {row['category']} "
+            f"(ppl={row['original_ppl']:.2f}, score={row['score']:.2f})"
         )
 
     # Last time rankings (what right labels should show)
@@ -420,7 +431,8 @@ def plot_bump(
     print("\nLast time rankings (RIGHT labels):")
     for _, row in last_data.iterrows():
         print(
-            f"  Rank {row['rank']}: {row['category']} (ppl={row['original_ppl']:.2f}, score={row['score']:.2f})"
+            f"  Rank {row['rank']}: {row['category']} "
+            f"(ppl={row['original_ppl']:.2f}, score={row['score']:.2f})"
         )
 
     print("\n=== End Debug ===\n")

--- a/scripts/plot_means.py
+++ b/scripts/plot_means.py
@@ -14,7 +14,7 @@ from dr_plotter.scripting.datadec_utils import get_datadec_functions, prepare_pl
 
 def create_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Plot mean training curves with faceted layout for DataDecide evaluation data"
+        description="Plot mean training curves with faceted layout for DataDecide eval"
     )
 
     # Faceting structure (mutually exclusive)
@@ -86,7 +86,7 @@ def create_arg_parser() -> argparse.ArgumentParser:
         "--legend",
         choices=["subplot", "grouped", "figure"],
         default="subplot",
-        help="Legend strategy: subplot (per-axes), grouped (by-channel), figure (single)",
+        help="Legend strategy: subplot (per-axes), grouped (by-channel), figure",
     )
 
     # Output (reused from plot_seeds)
@@ -165,7 +165,7 @@ def resolve_dimension_values(
 
 
 # TODO: Refactor this function - it's overly complex (86 statements, 28 branches)
-# Consider breaking into smaller functions for data preparation, plotting, and formatting
+# Consider breaking into smaller functions for data preparation, plotting, and format
 def plot_means(  # noqa: C901, PLR0912, PLR0915
     row: str | None = None,
     col: str | None = None,
@@ -227,11 +227,8 @@ def plot_means(  # noqa: C901, PLR0912, PLR0915
         elif dim == "data":
             if values:
                 all_data = resolve_dimension_values("data", values, dd, [], [], [])
-        elif dim == "metrics":
-            if values:
-                all_metrics = resolve_dimension_values(
-                    "metrics", values, dd, [], [], []
-                )
+        elif dim == "metrics" and values:
+            all_metrics = resolve_dimension_values("metrics", values, dd, [], [], [])
 
     # Use "all" for dimensions not explicitly specified
     if not all_params:

--- a/scripts/plot_means.py
+++ b/scripts/plot_means.py
@@ -164,7 +164,9 @@ def resolve_dimension_values(
         raise ValueError(f"Unknown dimension: {dimension}")
 
 
-def plot_means(
+# TODO: Refactor this function - it's overly complex (86 statements, 28 branches)
+# Consider breaking into smaller functions for data preparation, plotting, and formatting
+def plot_means(  # noqa: C901, PLR0912, PLR0915
     row: str | None = None,
     col: str | None = None,
     lines: str | None = None,
@@ -348,10 +350,7 @@ def plot_means(
         # Apply axis limits if specified
         if xlim or ylim:
             for facet_idx in range(nfacets):
-                if row:
-                    ax = fm.get_axes(facet_idx, 0)
-                else:
-                    ax = fm.get_axes(0, facet_idx)
+                ax = fm.get_axes(facet_idx, 0) if row else fm.get_axes(0, facet_idx)
                 if xlim:
                     ax.set_xlim(xlim)
                 if ylim:

--- a/scripts/plot_seeds.py
+++ b/scripts/plot_seeds.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 
 import argparse
 
@@ -11,7 +12,7 @@ from dr_plotter.scripting.datadec_utils import get_datadec_functions, prepare_pl
 
 def create_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Plot training curves with multiple seeds for DataDecide evaluation data"
+        description="Plot training curves with multiple seeds for DataDecide evaluation"
     )
 
     parser.add_argument(
@@ -22,7 +23,7 @@ def create_arg_parser() -> argparse.ArgumentParser:
         "--params",
         nargs="+",
         default=["all"],
-        help="Model parameter sizes to include (e.g., 10M 60M 90M) or 'all' for all available",
+        help="Model parameter sizes to include (e.g., 10M 60M 90M) or 'all'",
     )
 
     parser.add_argument(
@@ -50,7 +51,7 @@ def create_arg_parser() -> argparse.ArgumentParser:
         "--legend",
         choices=["subplot", "grouped", "figure"],
         default="subplot",
-        help="Legend strategy: subplot (per-axes), grouped (by-channel), figure (single)",
+        help="Legend strategy: subplot (per-axes), grouped (by-channel), figure",
     )
 
     parser.add_argument("--save", type=str, help="Save plot to file (specify path)")

--- a/src/dr_plotter/configs/layout_config.py
+++ b/src/dr_plotter/configs/layout_config.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field, fields
 from typing import Any
 
+TUPLE_MIN_ELEMENTS = 2
+TUPLE_MAX_ELEMENTS = 3
+
 
 @dataclass
 class LayoutConfig:
@@ -74,10 +77,10 @@ class LayoutConfig:
         elif isinstance(value, cls):
             return value
         elif isinstance(value, tuple):
-            assert len(value) in {2, 3}, (
-                f"Tuple must have 2 or 3 elements, got {len(value)}"
+            assert len(value) in {TUPLE_MIN_ELEMENTS, TUPLE_MAX_ELEMENTS}, (
+                f"Tuple must have {TUPLE_MIN_ELEMENTS} or {TUPLE_MAX_ELEMENTS} elements, got {len(value)}"
             )
-            if len(value) == 2:
+            if len(value) == TUPLE_MIN_ELEMENTS:
                 return cls(rows=value[0], cols=value[1])
             else:
                 return cls(rows=value[0], cols=value[1], **value[2])

--- a/src/dr_plotter/configs/layout_config.py
+++ b/src/dr_plotter/configs/layout_config.py
@@ -78,7 +78,9 @@ class LayoutConfig:
             return value
         elif isinstance(value, tuple):
             assert len(value) in {TUPLE_MIN_ELEMENTS, TUPLE_MAX_ELEMENTS}, (
-                f"Tuple must have {TUPLE_MIN_ELEMENTS} or {TUPLE_MAX_ELEMENTS} elements, got {len(value)}"
+                f"Tuple must have {TUPLE_MIN_ELEMENTS} or"
+                f" {TUPLE_MAX_ELEMENTS} elements, "
+                f"got {len(value)}"
             )
             if len(value) == TUPLE_MIN_ELEMENTS:
                 return cls(rows=value[0], cols=value[1])

--- a/src/dr_plotter/faceting/faceting_core.py
+++ b/src/dr_plotter/faceting/faceting_core.py
@@ -31,7 +31,8 @@ def prepare_faceted_subplots(
     if config.target_row is not None and config.target_col is not None:
         # Validate the target position is within the grid
         assert config.target_row < rows and config.target_col < cols, (
-            f"Target position ({config.target_row}, {config.target_col}) exceeds grid dimensions {grid_shape}"
+            f"Target position ({config.target_row}, {config.target_col}) "
+            f"exceeds grid dimensions {grid_shape}"
         )
 
         # When targeting a specific position, use all the data for that position

--- a/src/dr_plotter/faceting/faceting_core.py
+++ b/src/dr_plotter/faceting/faceting_core.py
@@ -309,7 +309,7 @@ def _apply_exterior_labels(
     row_values = _extract_dimension_values(data, config.rows, config.row_order)
     col_values = _extract_dimension_values(data, config.cols, config.col_order)
     n_rows = len(row_values) if config.rows else 1
-    n_cols = len(col_values) if config.cols else 1
+    n_cols = len(col_values) if config.cols else 1  # noqa: F841
 
     # Apply exterior x label (bottom row only)
     if config.exterior_x_label and row == n_rows - 1:

--- a/src/dr_plotter/faceting/style_coordination.py
+++ b/src/dr_plotter/faceting/style_coordination.py
@@ -57,10 +57,11 @@ class FacetStyleCoordinator:
 
         return self._style_assignments[dimension][value].copy()
 
+    # TODO: Consider if row/col parameters are needed for future subplot styling
     def get_subplot_styles(
         self,
-        row: int,
-        col: int,
+        row: int,  # noqa: ARG002
+        col: int,  # noqa: ARG002
         dimension: str | None,
         subplot_data: pd.DataFrame,
         **plot_kwargs: Any,

--- a/src/dr_plotter/plotters/base.py
+++ b/src/dr_plotter/plotters/base.py
@@ -235,7 +235,8 @@ class BasePlotter:
     def _resolve_computed_parameters(self, phase: str, context: dict) -> dict[str, Any]:  # noqa: ARG002
         return {}
 
-    # The _build_plot_args method has been removed as part of the configuration system refactoring.
+    # The _build_plot_args method has been removed as part of the configuration
+    # system refactoring.
     # All plotters now use _resolve_phase_config instead.
 
     def _should_create_legend(self) -> bool:
@@ -298,7 +299,7 @@ class BasePlotter:
     def _setup_group_context(
         self,
         group_info: GroupInfo,
-        group_index: int,
+        group_index: int,  # noqa: ARG002
         n_groups: int,  # noqa: ARG002
     ) -> GroupContext:
         name, group_data = group_info

--- a/src/dr_plotter/plotters/base.py
+++ b/src/dr_plotter/plotters/base.py
@@ -129,11 +129,12 @@ class BasePlotter:
     def _draw(self, ax: Any, data: pd.DataFrame, **kwargs: Any) -> None:
         pass
 
+    # TODO: Evaluate if group_position is needed for positioning logic
     def _draw_grouped(
         self,
         ax: Any,
         data: pd.DataFrame,
-        group_position: dict[str, Any],
+        group_position: dict[str, Any],  # noqa: ARG002
         **kwargs: Any,
     ) -> None:
         if not self.supports_grouped:
@@ -230,7 +231,8 @@ class BasePlotter:
         config.update(self._resolve_computed_parameters(phase, context))
         return config
 
-    def _resolve_computed_parameters(self, phase: str, context: dict) -> dict[str, Any]:
+    # TODO: Consider removing unused parameters if not needed by subclasses
+    def _resolve_computed_parameters(self, phase: str, context: dict) -> dict[str, Any]:  # noqa: ARG002
         return {}
 
     # The _build_plot_args method has been removed as part of the configuration system refactoring.
@@ -292,8 +294,12 @@ class BasePlotter:
             return self.plot_data[self.x_col].unique()
         return None
 
+    # TODO: Check if group_index/n_groups are needed for future group positioning
     def _setup_group_context(
-        self, group_info: GroupInfo, group_index: int, n_groups: int
+        self,
+        group_info: GroupInfo,
+        group_index: int,
+        n_groups: int,  # noqa: ARG002
     ) -> GroupContext:
         name, group_data = group_info
 
@@ -379,5 +385,6 @@ class BasePlotter:
         ylabel_text = styles.get("text", self.styler.get_style("ylabel", None))
         apply_ylabel_styling(ax, self.styler, ylabel_text)
 
-    def _style_grid(self, ax: Any, styles: dict[str, Any]) -> None:
+    # TODO: Determine if styles parameter should be used for grid customization
+    def _style_grid(self, ax: Any, styles: dict[str, Any]) -> None:  # noqa: ARG002
         apply_grid_styling(ax, self.styler)

--- a/src/dr_plotter/plotters/bump.py
+++ b/src/dr_plotter/plotters/bump.py
@@ -69,7 +69,7 @@ class BumpPlotter(BasePlotter):
         categories = self.plot_data[self.category_col].unique()
         self.trajectory_data = []
 
-        for i, category in enumerate(categories):
+        for _i, category in enumerate(categories):
             cat_data = self.plot_data[self.plot_data[self.category_col] == category]
             cat_data = cat_data.sort_values(by=self.time_col).copy()
 
@@ -92,7 +92,8 @@ class BumpPlotter(BasePlotter):
     ) -> dict[str, Any]:
         return {}
 
-    def _draw(self, ax: Any, data: pd.DataFrame, **kwargs: Any) -> None:
+    # TODO: Check if data parameter should be used instead of self.plot_data
+    def _draw(self, ax: Any, data: pd.DataFrame, **kwargs: Any) -> None:  # noqa: ARG002
         # Configure axis once before drawing trajectories
         self._configure_bump_axes(ax)
 

--- a/src/dr_plotter/positioning_calculator.py
+++ b/src/dr_plotter/positioning_calculator.py
@@ -72,11 +72,12 @@ class PositioningCalculator:
             tight_layout_pad=self.config.tight_layout_pad,
         )
 
+    # TODO: Implement manual positioning overrides for legend placement
     def _calculate_figure_legend_positions(
         self,
         figure_dimensions: FigureDimensions,
         legend_metadata: LegendMetadata,
-        manual_overrides: dict[str, Any],
+        manual_overrides: dict[str, Any],  # noqa: ARG002
     ) -> PositioningResult:
         num_legends = legend_metadata.num_legends
 

--- a/src/dr_plotter/scripting/bump_utils.py
+++ b/src/dr_plotter/scripting/bump_utils.py
@@ -5,6 +5,8 @@ from typing import Any
 import pandas as pd
 from datadec.model_utils import param_to_numeric
 
+MIN_TIME_POINTS_FOR_FILTERING = 2
+
 
 def apply_first_last_filter(
     bump_data: pd.DataFrame, time_col: str = "time", category_col: str = "category"
@@ -44,7 +46,7 @@ def apply_first_last_filter(
             # Numeric values like training steps - use regular numeric sorting
             time_points = sorted(time_values)
 
-        if len(time_points) < 2:
+        if len(time_points) < MIN_TIME_POINTS_FOR_FILTERING:
             filtered_data.append(cat_data)
         else:
             first_last = cat_data[

--- a/src/dr_plotter/scripting/datadec_utils.py
+++ b/src/dr_plotter/scripting/datadec_utils.py
@@ -34,7 +34,7 @@ def get_datadec_constants() -> tuple[
     metric_names = datadec.constants.METRIC_NAMES
     primary_metric_name = "primary_metric"
     default_proxy_metric_name = "correct_prob"
-    id_cols = ["params", "data", "step", "tokens","seed"]
+    id_cols = ["params", "data", "step", "tokens", "seed"]
 
     return (
         ppl_metrics,

--- a/src/dr_plotter/scripting/datadec_utils.py
+++ b/src/dr_plotter/scripting/datadec_utils.py
@@ -34,7 +34,7 @@ def get_datadec_constants() -> tuple[
     metric_names = datadec.constants.METRIC_NAMES
     primary_metric_name = "primary_metric"
     default_proxy_metric_name = "correct_prob"
-    id_cols = ["params", "data", "step", "seed"]
+    id_cols = ["params", "data", "step", "tokens","seed"]
 
     return (
         ppl_metrics,


### PR DESCRIPTION
### TL;DR

Added a new example script for visualizing model performance across different scales and added tokens to ID columns in datadec_utils.

### What changed?

- Added a new example script `MI_lines.py` that visualizes model performance (PPL) across different model sizes (20M, 60M, 90M, 530M) on the Dolma1.7 dataset
- The script creates a 2x4 grid of plots showing different scaling relationships:
  - Top row: PPL vs tokens with various axis scales (linear-linear, linear-log, log-linear, log-log)
  - Bottom row: PPL vs percentage of training with various axis scales
- Added a `normalize_df` function to normalize values for better comparison
- Updated `id_cols` in `datadec_utils.py` to include "tokens" as an identifier column

### How to test?

1. Run the new example script:
```
python examples/MI_lines.py
```
2. Verify that the script generates a figure with 8 subplots showing model performance across different scales
3. Check that the plots correctly display the normalized performance metrics with appropriate axis scales

### Why make this change?

This change enables visualization of model performance scaling across different model sizes, making it easier to analyze how performance improves with more parameters and training tokens. The various plot configurations (linear vs log scales) help reveal different aspects of the scaling relationships, which is valuable for understanding model training dynamics and efficiency.