### PR TITLE
Add YAML configuration support and CLI framework for dr_plotter

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -1,0 +1,44 @@
+# dr_plotter Configuration Examples
+
+This directory contains example YAML configuration files for the dr_plotter CLI framework.
+
+## Files
+
+- **`example_config.yaml`** - Complete configuration showing all available options
+- **`minimal_config.yaml`** - Minimal configuration with common settings  
+- **`demo_config.yaml`** - Configuration used by the demo script
+
+## Usage
+
+```bash
+# Use with demo script
+uv run python scripts/plot_scaling_demo.py --config configs/example_config.yaml
+
+# Use with your own applications
+from dr_plotter.scripting import CLIConfig
+config = CLIConfig.from_yaml('configs/example_config.yaml')
+```
+
+## Configuration Structure
+
+The YAML files mirror dr_plotter's config objects:
+
+```yaml
+faceting:          # → FacetingConfig options
+  rows_and_cols: model_size
+  hue_by: dataset
+  fixed_dimensions:
+    metric: loss
+    
+layout:            # → Layout options
+  subplot_width: 3.5
+  subplot_height: 3.0
+  
+legend:            # → LegendConfig options
+  strategy: grouped
+  
+output:            # → Output options
+  save_dir: ./plots
+```
+
+See the example files for complete option references.

--- a/configs/demo_config.yaml
+++ b/configs/demo_config.yaml
@@ -1,0 +1,11 @@
+# dr_plotter dimensional plotting configuration
+# This file demonstrates the YAML config structure
+
+faceting:
+  rows_and_cols: model_size
+  hue_by: dataset
+  alpha_by: seed
+  fixed_dimensions:
+    metric: loss
+legend:
+  strategy: grouped

--- a/configs/example_config.yaml
+++ b/configs/example_config.yaml
@@ -1,0 +1,34 @@
+# dr_plotter dimensional plotting configuration
+# This file demonstrates the YAML config structure
+
+faceting:
+  rows: null
+  cols: null
+  rows_and_cols: model_size
+  max_cols: 4
+  hue_by: dataset
+  alpha_by: seed
+  size_by: null
+  marker_by: null
+  style_by: null
+  fixed_dimensions:
+    metric: loss
+  ordered_dimensions:
+    model_size:
+    - 1B
+    - 7B
+    - 30B
+    - 70B
+    - 180B
+  exclude_dimensions:
+    dataset:
+    - deprecated_data
+layout:
+  subplot_width: 3.5
+  subplot_height: 3.0
+  auto_titles: true
+legend:
+  strategy: grouped
+output:
+  save_dir: ./plots
+  pause: 5

--- a/configs/minimal_config.yaml
+++ b/configs/minimal_config.yaml
@@ -1,0 +1,10 @@
+# dr_plotter dimensional plotting configuration
+# This file demonstrates the YAML config structure
+
+faceting:
+  rows_and_cols: params
+  hue_by: data
+  fixed_dimensions:
+    metric: pile-valppl
+legend:
+  strategy: figure

--- a/examples/00_basic_functionality.py
+++ b/examples/00_basic_functionality.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter.configs import PlotConfig
 from dr_plotter.figure_manager import FigureManager

--- a/examples/01_basic_line.py
+++ b/examples/01_basic_line.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter.configs import (
     PlotConfig,

--- a/examples/02_visual_encoding.py
+++ b/examples/02_visual_encoding.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter.configs import PlotConfig
 from dr_plotter.figure_manager import FigureManager

--- a/examples/03_layout_composition.py
+++ b/examples/03_layout_composition.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter.configs import PlotConfig
 from dr_plotter.figure_manager import FigureManager

--- a/examples/04_specialized_plots.py
+++ b/examples/04_specialized_plots.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter.configs import PlotConfig
 from dr_plotter.figure_manager import FigureManager

--- a/examples/05_all_plot_types.py
+++ b/examples/05_all_plot_types.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import pandas as pd
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter.configs import PlotConfig
 from dr_plotter.figure_manager import FigureManager

--- a/examples/06_individual_vs_grouped.py
+++ b/examples/06_individual_vs_grouped.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter.configs import PlotConfig
 from dr_plotter.figure_manager import FigureManager

--- a/examples/07_grouped_plotting.py
+++ b/examples/07_grouped_plotting.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter.configs import PlotConfig
 from dr_plotter.figure_manager import FigureManager

--- a/examples/08_individual_styling.py
+++ b/examples/08_individual_styling.py
@@ -1,7 +1,7 @@
 import itertools
 from typing import Any
 
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter.configs import PlotConfig
 from dr_plotter.figure_manager import FigureManager

--- a/examples/09_cross_groupby_legends.py
+++ b/examples/09_cross_groupby_legends.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter.configs import PlotConfig
 from dr_plotter.figure_manager import FigureManager

--- a/examples/10_legend_positioning.py
+++ b/examples/10_legend_positioning.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter.configs import LayoutConfig, PlotConfig
 from dr_plotter.figure_manager import FigureManager

--- a/examples/11_line_showcase.py
+++ b/examples/11_line_showcase.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter import consts
 from dr_plotter.configs import PlotConfig

--- a/examples/12_violin_showcase.py
+++ b/examples/12_violin_showcase.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter.configs import PlotConfig
 from dr_plotter.figure_manager import FigureManager

--- a/examples/13_heatmap_showcase.py
+++ b/examples/13_heatmap_showcase.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter.configs import PlotConfig
 from dr_plotter.figure_manager import FigureManager

--- a/examples/14_contour_showcase.py
+++ b/examples/14_contour_showcase.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter.configs import PlotConfig
 from dr_plotter.figure_manager import FigureManager

--- a/examples/15_layering_plots.py
+++ b/examples/15_layering_plots.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import numpy as np
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter.configs import PlotConfig
 from dr_plotter.figure_manager import FigureManager

--- a/examples/16_matplotlib_integration.py
+++ b/examples/16_matplotlib_integration.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter.configs import PlotConfig
 from dr_plotter.figure_manager import FigureManager

--- a/examples/17_custom_plotters.py
+++ b/examples/17_custom_plotters.py
@@ -1,7 +1,7 @@
 from typing import Any, ClassVar
 
 import pandas as pd
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter import consts
 from dr_plotter.configs import PlotConfig

--- a/examples/18_scientific_figures.py
+++ b/examples/18_scientific_figures.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter.configs import PlotConfig
 from dr_plotter.figure_manager import FigureManager

--- a/examples/19_ml_dashboard.py
+++ b/examples/19_ml_dashboard.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter import consts
 from dr_plotter.configs import PlotConfig

--- a/examples/20_bar_showcase.py
+++ b/examples/20_bar_showcase.py
@@ -5,7 +5,7 @@ Demonstrates single and grouped bar plots.
 
 from typing import Any
 
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter.configs import PlotConfig
 from dr_plotter.figure_manager import FigureManager

--- a/examples/21_legend_positioning_showcase.py
+++ b/examples/21_legend_positioning_showcase.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter.configs import PlotConfig
 from dr_plotter.figure_manager import FigureManager

--- a/examples/22_themed_color_coordination.py
+++ b/examples/22_themed_color_coordination.py
@@ -2,7 +2,7 @@ import itertools
 from typing import Any
 
 import pandas as pd
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter.configs import PlotConfig
 from dr_plotter.figure_manager import FigureManager

--- a/examples/23_color_coordination.py
+++ b/examples/23_color_coordination.py
@@ -5,7 +5,7 @@ Demonstrates consistent colors across multiple subplots using FigureManager.
 
 from typing import Any
 
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter.configs import PlotConfig
 from dr_plotter.figure_manager import FigureManager

--- a/examples/24_multi_series_plotting.py
+++ b/examples/24_multi_series_plotting.py
@@ -5,7 +5,7 @@ Demonstrates all visual encoding options: hue, style, size, marker, alpha.
 
 from typing import Any
 
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter.configs import PlotConfig
 from dr_plotter.figure_manager import FigureManager

--- a/examples/26_scatter_showcase.py
+++ b/examples/26_scatter_showcase.py
@@ -5,7 +5,7 @@ Demonstrates all visual encoding options for scatter plots.
 
 from typing import Any
 
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter.configs import PlotConfig
 from dr_plotter.figure_manager import FigureManager

--- a/examples/27_multi_metric_plotting.py
+++ b/examples/27_multi_metric_plotting.py
@@ -5,7 +5,7 @@ Demonstrates plotting multiple y-columns with the METRICS constant.
 
 from typing import Any
 
-from plot_data import ExampleData
+from dr_plotter.scripting import ExampleData
 
 from dr_plotter import consts
 from dr_plotter.configs import PlotConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,12 @@ dependencies = [
     "scikit-learn>=1.6.1",
     "pydantic>=2.11.7",
     "pyarrow>=21.0.0",
+    "click>=8.0.0",  # CLI framework for example scripts
+    "PyYAML>=6.0.0",  # YAML config file support
 ]
+
+[project.scripts]
+dr-plotter = "dr_plotter.scripting.cli:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/scripts/plot_scaling_demo.py
+++ b/scripts/plot_scaling_demo.py
@@ -13,16 +13,16 @@ import pandas as pd
 import click
 
 from dr_plotter import FigureManager
-from dr_plotter.configs import (
-    FacetingConfig,
-    LayoutConfig,
-    LegendConfig,
-    PlotConfig,
-    StyleConfig,
+from dr_plotter.scripting import (
+    CLIConfig,
+    dimensional_plotting_cli,
+    validate_layout_options,
+    build_faceting_config,
+    build_plot_config,
+    validate_dimensions_interactive,
 )
-from dr_plotter.scripting.utils import parse_key_value_args, show_or_save_plot
+from dr_plotter.scripting.utils import show_or_save_plot
 from dr_plotter.theme import BASE_THEME, Theme, FigureStyles
-from dr_plotter.faceting.dimension_validation import interactive_dimension_validation
 
 
 # 🎨 DEMO THEME - Shows customization patterns
@@ -121,127 +121,55 @@ def generate_scaling_data(n_points: int = 100) -> pd.DataFrame:
 
 
 @click.command()
-@click.option("--config", type=click.Path(exists=True), help="YAML configuration file")
-@click.option(
-    "--rows",
-    type=click.Choice(["model_size", "dataset", "metric"]),
-    help="Facet by rows",
-)
-@click.option(
-    "--cols",
-    type=click.Choice(["model_size", "dataset", "metric"]),
-    help="Facet by columns",
-)
-@click.option(
-    "--rows-and-cols",
-    type=click.Choice(["model_size", "dataset"]),
-    help="Wrap dimension across grid",
-)
-@click.option("--max-cols", type=int, default=4, help="Max columns for wrapped layout")
-@click.option(
-    "--hue-by",
-    type=click.Choice(["model_size", "dataset", "metric", "seed"]),
-    help="Color grouping",
-)
-@click.option(
-    "--alpha-by",
-    type=click.Choice(["model_size", "dataset", "metric", "seed"]),
-    help="Transparency grouping",
-)
-@click.option(
-    "--size-by",
-    type=click.Choice(["model_size", "dataset", "metric", "seed"]),
-    help="Size grouping",
-)
-@click.option(
-    "--fixed", multiple=True, help="Fixed dimensions: key=value (e.g., --fixed seed=0)"
-)
-@click.option(
-    "--order",
-    multiple=True,
-    help="Ordered dimensions: key=val1,val2 (e.g., --order dataset=Wikipedia,Books)",
-)
-@click.option("--exclude", multiple=True, help="Exclude values: key=val1,val2")
-@click.option("--subplot-width", type=float, default=3.5, help="Subplot width")
-@click.option("--subplot-height", type=float, default=3.0, help="Subplot height")
-@click.option("--no-auto-titles", is_flag=True, help="Disable automatic titles")
-@click.option(
-    "--legend-strategy",
-    type=click.Choice(["subplot", "figure", "grouped", "none"]),
-    default="subplot",
-)
-@click.option("--save-dir", help="Save plots to directory")
-@click.option("--pause", type=int, default=5, help="Display duration")
+@dimensional_plotting_cli(["model_size", "dataset", "metric", "seed"])
 @click.option(
     "--n-points", type=int, default=50, help="Number of data points to generate"
 )
 def main(**kwargs):
     """Generate and plot synthetic ML scaling data with dimensional faceting."""
 
-    # Handle config file loading (placeholder for now)
+    # Load configuration
+    config = CLIConfig()
     if kwargs.get("config"):
-        click.echo(f"Config file support coming soon: {kwargs['config']}")
+        try:
+            config = CLIConfig.from_yaml(kwargs["config"])
+            click.echo(f"✅ Loaded configuration from {kwargs['config']}")
+        except Exception as e:
+            click.echo(f"❌ Error loading config: {e}")
+            return
 
-    # Validate layout
-    layout_options = [kwargs["rows"], kwargs["cols"], kwargs["rows_and_cols"]]
-    specified_layouts = [opt for opt in layout_options if opt is not None]
-    if len(specified_layouts) == 0:
-        raise click.UsageError(
-            "Must specify one of: --rows, --cols, or --rows-and-cols"
-        )
-    if len(specified_layouts) > 1:
-        raise click.UsageError("Specify only one layout option")
+    # Remove config file path from kwargs since we pass CLIConfig object separately
+    cli_kwargs = {k: v for k, v in kwargs.items() if k != "config"}
+
+    # Merge config with CLI args for validation
+    merged_args = config.merge_with_cli_args(cli_kwargs)
+
+    # Validate layout with merged arguments
+    validate_layout_options(click.get_current_context(), **merged_args)
 
     # Generate synthetic data
     click.echo(f"Generating {kwargs['n_points']} data points per combination...")
     df = generate_scaling_data(kwargs["n_points"])
     click.echo(f"Generated {len(df)} total data points")
 
-    # Parse dimensional control arguments
-    fixed_dimensions = parse_key_value_args(kwargs["fixed"])
-    ordered_dimensions = parse_key_value_args(kwargs["order"])
-    exclude_dimensions = parse_key_value_args(kwargs["exclude"])
-
-    # Create faceting configuration
-    faceting_config = FacetingConfig(
+    # Create faceting configuration using framework
+    # Remove config file path from kwargs since we pass CLIConfig object separately
+    cli_kwargs = {k: v for k, v in kwargs.items() if k != "config"}
+    faceting_config = build_faceting_config(
+        config,
         x="step",
         y="value",
-        rows=kwargs["rows"],
-        cols=kwargs["cols"],
-        rows_and_cols=kwargs["rows_and_cols"],
-        max_cols=kwargs["max_cols"] if kwargs["rows_and_cols"] else None,
-        hue_by=kwargs["hue_by"],
-        alpha_by=kwargs["alpha_by"],
-        size_by=kwargs["size_by"],
-        fixed_dimensions=fixed_dimensions if fixed_dimensions else None,
-        ordered_dimensions=ordered_dimensions if ordered_dimensions else None,
-        exclude_dimensions=exclude_dimensions if exclude_dimensions else None,
-        subplot_width=kwargs["subplot_width"],
-        subplot_height=kwargs["subplot_height"],
-        auto_titles=not kwargs["no_auto_titles"],
-        row_titles=(not kwargs["no_auto_titles"]) if kwargs["rows"] else False,
-        col_titles=(not kwargs["no_auto_titles"]) if kwargs["cols"] else False,
         exterior_x_label="Training Steps",
         exterior_y_label="Metric Value",
+        **cli_kwargs,
     )
 
     # Validate dimensional usage
-    click.echo("Validating dimensional configuration...")
-    if not interactive_dimension_validation(df, faceting_config):
-        click.echo("Aborted by user.")
+    if not validate_dimensions_interactive(df, faceting_config):
         return
 
-    # Create plot configuration
-    plot_config = PlotConfig(
-        layout=LayoutConfig(
-            rows=1,
-            cols=1,
-            tight_layout=True,
-            tight_layout_pad=1.0,
-        ),
-        legend=LegendConfig(strategy=kwargs["legend_strategy"]),
-        style=StyleConfig(theme=DEMO_THEME),
-    )
+    # Create plot configuration using framework
+    plot_config = build_plot_config(config, theme=DEMO_THEME, **cli_kwargs)
 
     # Generate plot
     click.echo("Creating dimensional plot...")

--- a/src/dr_plotter/scripting/__init__.py
+++ b/src/dr_plotter/scripting/__init__.py
@@ -20,6 +20,7 @@ from .config_schema import (
     validate_config,
     load_and_validate_config,
 )
+from .plot_data import ExampleData
 
 __all__ = [
     # Legacy utils
@@ -45,4 +46,6 @@ __all__ = [
     "write_example_config",
     "validate_config",
     "load_and_validate_config",
+    # Example data
+    "ExampleData",
 ]

--- a/src/dr_plotter/scripting/__init__.py
+++ b/src/dr_plotter/scripting/__init__.py
@@ -1,3 +1,48 @@
 from .utils import setup_arg_parser, show_or_save_plot, create_and_render_plot
+from .cli_framework import (
+    CLIConfig,
+    dimensional_plotting_cli,
+    common_faceting_options,
+    dimensional_control_options,
+    layout_options,
+    legend_options,
+    output_options,
+    config_option,
+    validate_layout_options,
+    build_faceting_config,
+    build_plot_config,
+    validate_dimensions_interactive,
+)
+from .config_schema import (
+    EXAMPLE_CONFIG,
+    MINIMAL_CONFIG,
+    write_example_config,
+    validate_config,
+    load_and_validate_config,
+)
 
-__all__ = ["create_and_render_plot", "setup_arg_parser", "show_or_save_plot"]
+__all__ = [
+    # Legacy utils
+    "create_and_render_plot",
+    "setup_arg_parser",
+    "show_or_save_plot",
+    # CLI Framework
+    "CLIConfig",
+    "dimensional_plotting_cli",
+    "common_faceting_options",
+    "dimensional_control_options",
+    "layout_options",
+    "legend_options",
+    "output_options",
+    "config_option",
+    "validate_layout_options",
+    "build_faceting_config",
+    "build_plot_config",
+    "validate_dimensions_interactive",
+    # Config support
+    "EXAMPLE_CONFIG",
+    "MINIMAL_CONFIG",
+    "write_example_config",
+    "validate_config",
+    "load_and_validate_config",
+]

--- a/src/dr_plotter/scripting/cli.py
+++ b/src/dr_plotter/scripting/cli.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+Global dr-plotter CLI entry point.
+
+Provides a global command for creating dimensional plots from data files
+using the dr_plotter CLI framework.
+"""
+
+from __future__ import annotations
+
+import click
+import pandas as pd
+from pathlib import Path
+
+from dr_plotter import FigureManager
+from dr_plotter.scripting import (
+    CLIConfig,
+    dimensional_plotting_cli,
+    validate_layout_options,
+    build_faceting_config,
+    build_plot_config,
+    validate_dimensions_interactive,
+)
+from dr_plotter.scripting.utils import show_or_save_plot
+from dr_plotter.theme import BASE_THEME, Theme, FigureStyles
+
+
+# Global CLI theme for dr-plotter command
+CLI_THEME = Theme(
+    name="dr_plotter_cli",
+    parent=BASE_THEME,
+    figure_styles=FigureStyles(
+        legend_position=(0.5, 0.02),
+        multi_legend_positions=[(0.3, 0.02), (0.7, 0.02)],
+        subplot_width=3.5,
+        subplot_height=3.0,
+        row_title_rotation=90,
+        legend_frameon=True,
+        legend_tight_layout_rect=(0, 0.08, 1, 1),
+    ),
+)
+
+
+def load_dataset(file_path: str) -> pd.DataFrame:
+    """Load dataset from file."""
+    path = Path(file_path).expanduser()
+    
+    if not path.exists():
+        raise FileNotFoundError(f"Dataset not found: {path}")
+    
+    # Load based on file extension
+    if path.suffix == '.parquet':
+        df = pd.read_parquet(path)
+    elif path.suffix == '.csv':
+        df = pd.read_csv(path)
+    elif path.suffix == '.json':
+        df = pd.read_json(path)
+    else:
+        raise ValueError(f"Unsupported file format: {path.suffix}")
+    
+    click.echo(f"Loaded {len(df)} rows from {path}")
+    click.echo(f"Columns: {list(df.columns)}")
+    
+    return df
+
+
+@click.command()
+@click.argument('dataset_path', type=click.Path())
+@click.option(
+    '--x', 'x_column', 
+    help="Column name for x-axis (default: auto-detect from step/time/x)"
+)
+@click.option(
+    '--y', 'y_column',
+    help="Column name for y-axis (default: auto-detect from value/y)"
+)
+@click.option(
+    '--dimensions',
+    help="Comma-separated list of valid dimension column names (enables validation)"
+)
+@dimensional_plotting_cli([])  # Empty list - validation handled conditionally
+def main(dataset_path: str, x_column: str | None, y_column: str | None, dimensions: str | None, **kwargs):
+    """Create dimensional plots from data files using dr_plotter framework.
+    
+    DATASET_PATH: Path to your data file (.parquet, .csv, or .json)
+    
+    Examples:
+    
+        # Basic usage with config file
+        dr-plotter ~/data/results.parquet --config my_config.yaml
+        
+        # Specify columns and dimensions explicitly
+        dr-plotter data.parquet --x step --y loss --dimensions "model,dataset,seed" --rows-and-cols model --hue-by dataset
+        
+        # DataDec example
+        dr-plotter ~/drotherm/repos/datadec/data/datadecide/full_eval_melted.parquet --rows-and-cols params --hue-by data
+    """
+    
+    try:
+        # Load the dataset
+        df = load_dataset(dataset_path)
+    except Exception as e:
+        click.echo(f"❌ Error loading dataset: {e}")
+        return
+    
+    # Determine x and y columns
+    if not x_column:
+        for col in ['step', 'time', 'x']:
+            if col in df.columns:
+                x_column = col
+                break
+        if not x_column:
+            click.echo("❌ Could not auto-detect x column. Please specify with --x")
+            return
+    
+    if not y_column:
+        for col in ['value', 'y', 'loss', 'accuracy']:
+            if col in df.columns:
+                y_column = col
+                break
+        if not y_column:
+            click.echo("❌ Could not auto-detect y column. Please specify with --y")
+            return
+    
+    click.echo(f"Using x='{x_column}', y='{y_column}'")
+    
+    # Load configuration
+    config = CLIConfig()
+    if kwargs.get("config"):
+        try:
+            config = CLIConfig.from_yaml(kwargs["config"])
+            click.echo(f"✅ Loaded configuration from {kwargs['config']}")
+        except Exception as e:
+            click.echo(f"❌ Error loading config: {e}")
+            return
+
+    # Remove config file path from kwargs since we pass CLIConfig object separately
+    cli_kwargs = {k: v for k, v in kwargs.items() if k != "config"}
+    
+    # Conditional validation based on --dimensions
+    if dimensions:
+        # User provided dimensions - do full validation
+        valid_dims = [d.strip() for d in dimensions.split(',')]
+        click.echo(f"Validating dimensions: {valid_dims}")
+        
+        # Validate dimensions exist in data
+        for dim in valid_dims:
+            if dim not in df.columns:
+                click.echo(f"❌ Dimension '{dim}' not found in dataset columns: {list(df.columns)}")
+                return
+        
+        # Validate CLI args use valid dimensions
+        for key, value in cli_kwargs.items():
+            if key in ['rows', 'cols', 'rows_and_cols', 'hue_by', 'alpha_by', 'size_by'] and value:
+                if value not in valid_dims:
+                    click.echo(f"❌ '{value}' not in specified dimensions: {valid_dims}")
+                    return
+        
+        # Merge config with CLI args for validation  
+        merged_args = config.merge_with_cli_args(cli_kwargs)
+        
+        # Validate layout with merged arguments
+        validate_layout_options(click.get_current_context(), **merged_args)
+    else:
+        # No dimensions specified - skip validation, let faceting crash naturally
+        click.echo("⚠️  No --dimensions specified. Skipping validation - errors will crash with clear messages.")
+        merged_args = config.merge_with_cli_args(cli_kwargs)
+
+    # Create faceting configuration using framework
+    faceting_config = build_faceting_config(
+        config,
+        x=x_column,
+        y=y_column,
+        exterior_x_label=x_column.title(),
+        exterior_y_label=y_column.title(),
+        **cli_kwargs,
+    )
+
+    # Skip validate_dimensions_interactive - too many false positives for general use
+    # Let natural errors from bad column names provide feedback instead
+
+    # Create plot configuration using framework
+    plot_config = build_plot_config(config, theme=CLI_THEME, **cli_kwargs)
+
+    # Generate plot - use line plot for time-series like data, scatter otherwise
+    plot_type = "line" if x_column in ['step', 'time', 'epoch'] else "scatter"
+    click.echo(f"Creating dimensional {plot_type} plot...")
+    
+    with FigureManager(plot_config) as fm:
+        if plot_type == "line":
+            fm.plot_faceted(df, "line", faceting=faceting_config, linewidth=1.5)
+        else:
+            fm.plot_faceted(df, "scatter", faceting=faceting_config, s=50, alpha=0.7)
+
+    # Handle output
+    class Args:
+        save_dir = kwargs["save_dir"]
+        pause = kwargs["pause"]
+
+    dataset_name = Path(dataset_path).stem
+    show_or_save_plot(fm.fig, Args(), f"dr_plotter_{dataset_name}")
+    click.echo("✅ dr-plotter completed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dr_plotter/scripting/cli_framework.py
+++ b/src/dr_plotter/scripting/cli_framework.py
@@ -1,0 +1,359 @@
+"""
+Professional CLI framework for dimensional plotting with dr_plotter.
+
+This module provides reusable Click-based CLI components that can be extended
+by applications like datadec while maintaining consistency and best practices.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Optional, Union, TypeVar
+import click
+import yaml
+from pathlib import Path
+
+from dr_plotter.configs import (
+    FacetingConfig,
+    LayoutConfig,
+    LegendConfig,
+    PlotConfig,
+    StyleConfig,
+)
+from dr_plotter.scripting.utils import parse_key_value_args
+from dr_plotter.faceting.dimension_validation import interactive_dimension_validation
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+class CLIConfig:
+    """Container for CLI configuration with YAML support."""
+
+    def __init__(self, config_data: Optional[Dict[str, Any]] = None):
+        self.data = config_data or {}
+
+    @classmethod
+    def from_yaml(cls, config_path: Union[str, Path]) -> CLIConfig:
+        """Load configuration from YAML file."""
+        with open(config_path) as f:
+            data = yaml.safe_load(f)
+        return cls(data)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Get configuration value with dot notation support."""
+        keys = key.split(".")
+        value = self.data
+        for k in keys:
+            if isinstance(value, dict) and k in value:
+                value = value[k]
+            else:
+                return default
+        return value
+
+    def merge_with_cli_args(self, cli_args: Dict[str, Any]) -> Dict[str, Any]:
+        """Merge config with CLI arguments, giving precedence to CLI."""
+        # Start with config values
+        merged = {}
+
+        # Map config sections to CLI argument names
+        config_mappings = {
+            "faceting.rows": "rows",
+            "faceting.cols": "cols",
+            "faceting.rows_and_cols": "rows_and_cols",
+            "faceting.max_cols": "max_cols",
+            "faceting.hue_by": "hue_by",
+            "faceting.alpha_by": "alpha_by",
+            "faceting.size_by": "size_by",
+            "faceting.marker_by": "marker_by",
+            "faceting.style_by": "style_by",
+            "faceting.fixed_dimensions": "fixed",
+            "faceting.ordered_dimensions": "order",
+            "faceting.exclude_dimensions": "exclude",
+            "layout.subplot_width": "subplot_width",
+            "layout.subplot_height": "subplot_height",
+            "layout.auto_titles": "auto_titles",
+            "legend.strategy": "legend_strategy",
+            "output.save_dir": "save_dir",
+            "output.pause": "pause",
+        }
+
+        # Apply config defaults
+        for config_key, cli_key in config_mappings.items():
+            config_value = self.get(config_key)
+            if config_value is not None:
+                merged[cli_key] = config_value
+
+        # Override with CLI arguments (only if not None and not empty)
+        for key, value in cli_args.items():
+            if value is not None and value != () and value != [] and value != "":
+                merged[key] = value
+
+        return merged
+
+
+def common_faceting_options(valid_dimensions: List[str]) -> Callable[[F], F]:
+    """Add common faceting options to a Click command."""
+
+    def decorator(f: F) -> F:
+        # Layout options
+        f = click.option(
+            "--rows",
+            type=click.Choice(valid_dimensions),
+            help="Dimension to use for row faceting",
+        )(f)
+        f = click.option(
+            "--cols",
+            type=click.Choice(valid_dimensions),
+            help="Dimension to use for column faceting",
+        )(f)
+        f = click.option(
+            "--rows-and-cols",
+            type=click.Choice(valid_dimensions),
+            help="Dimension to wrap across rows and columns",
+        )(f)
+        f = click.option(
+            "--max-cols",
+            type=int,
+            default=4,
+            help="Maximum columns for wrapping layout",
+        )(f)
+
+        # Visual channels
+        f = click.option(
+            "--hue-by",
+            type=click.Choice(valid_dimensions),
+            help="Dimension for color/line grouping",
+        )(f)
+        f = click.option(
+            "--alpha-by",
+            type=click.Choice(valid_dimensions),
+            help="Dimension for transparency grouping",
+        )(f)
+        f = click.option(
+            "--size-by",
+            type=click.Choice(valid_dimensions),
+            help="Dimension for size grouping",
+        )(f)
+        f = click.option(
+            "--marker-by",
+            type=click.Choice(valid_dimensions),
+            help="Dimension for marker style grouping",
+        )(f)
+        f = click.option(
+            "--style-by",
+            type=click.Choice(valid_dimensions),
+            help="Dimension for line style grouping",
+        )(f)
+
+        return f
+
+    return decorator
+
+
+def dimensional_control_options() -> Callable[[F], F]:
+    """Add dimensional control options to a Click command."""
+
+    def decorator(f: F) -> F:
+        f = click.option(
+            "--fixed",
+            multiple=True,
+            help="Fixed dimensions: key=value (e.g., --fixed seed=0)",
+        )(f)
+        f = click.option(
+            "--order",
+            multiple=True,
+            help="Ordered dimensions: key=val1,val2 (e.g., --order params=7B,30B,70B)",
+        )(f)
+        f = click.option(
+            "--exclude",
+            multiple=True,
+            help="Exclude values: key=val1,val2 (e.g., --exclude params=1B,2B)",
+        )(f)
+
+        return f
+
+    return decorator
+
+
+def layout_options() -> Callable[[F], F]:
+    """Add layout and styling options to a Click command."""
+
+    def decorator(f: F) -> F:
+        f = click.option(
+            "--subplot-width", type=float, default=3.5, help="Width of each subplot"
+        )(f)
+        f = click.option(
+            "--subplot-height", type=float, default=3.0, help="Height of each subplot"
+        )(f)
+        f = click.option(
+            "--no-auto-titles",
+            is_flag=True,
+            help="Disable automatic descriptive titles",
+        )(f)
+
+        return f
+
+    return decorator
+
+
+def legend_options() -> Callable[[F], F]:
+    """Add legend configuration options to a Click command."""
+
+    def decorator(f: F) -> F:
+        f = click.option(
+            "--legend-strategy",
+            type=click.Choice(["subplot", "figure", "grouped", "none"]),
+            default="subplot",
+            help="Legend placement strategy",
+        )(f)
+
+        return f
+
+    return decorator
+
+
+def output_options() -> Callable[[F], F]:
+    """Add output control options to a Click command."""
+
+    def decorator(f: F) -> F:
+        f = click.option("--save-dir", help="Directory to save plots")(f)
+        f = click.option(
+            "--pause", type=int, default=5, help="Display duration in seconds"
+        )(f)
+
+        return f
+
+    return decorator
+
+
+def config_option() -> Callable[[F], F]:
+    """Add YAML config file support to a Click command."""
+
+    def decorator(f: F) -> F:
+        f = click.option(
+            "--config", type=click.Path(exists=True), help="YAML configuration file"
+        )(f)
+
+        return f
+
+    return decorator
+
+
+def validate_layout_options(ctx: click.Context, **kwargs) -> None:
+    """Validate that exactly one layout option is specified."""
+    layout_options = [
+        kwargs.get("rows"),
+        kwargs.get("cols"),
+        kwargs.get("rows_and_cols"),
+    ]
+    specified_layouts = [opt for opt in layout_options if opt is not None]
+
+    if len(specified_layouts) == 0:
+        raise click.UsageError(
+            "Must specify one of: --rows, --cols, or --rows-and-cols"
+        )
+    if len(specified_layouts) > 1:
+        raise click.UsageError("Specify only one layout option")
+
+
+def build_faceting_config(
+    config: CLIConfig,
+    x: str = "step",
+    y: str = "value",
+    exterior_x_label: str = "Steps",
+    exterior_y_label: str = "Value",
+    **cli_overrides,
+) -> FacetingConfig:
+    """Build FacetingConfig from CLI arguments and config file."""
+    # Merge config with CLI overrides
+    merged = config.merge_with_cli_args(cli_overrides)
+
+    # Parse dimensional control arguments (handle both CLI strings and config dicts)
+    def parse_dimension_value(value):
+        if isinstance(value, dict):
+            return value  # Already parsed from config file
+        elif isinstance(value, (list, tuple)) and value:
+            return parse_key_value_args(value)  # Parse CLI arguments
+        else:
+            return None
+
+    fixed_dimensions = parse_dimension_value(merged.get("fixed"))
+    ordered_dimensions = parse_dimension_value(merged.get("order"))
+    exclude_dimensions = parse_dimension_value(merged.get("exclude"))
+
+    return FacetingConfig(
+        x=x,
+        y=y,
+        rows=merged.get("rows"),
+        cols=merged.get("cols"),
+        rows_and_cols=merged.get("rows_and_cols"),
+        max_cols=merged.get("max_cols") if merged.get("rows_and_cols") else None,
+        hue_by=merged.get("hue_by"),
+        alpha_by=merged.get("alpha_by"),
+        size_by=merged.get("size_by"),
+        marker_by=merged.get("marker_by"),
+        style_by=merged.get("style_by"),
+        fixed_dimensions=fixed_dimensions if fixed_dimensions else None,
+        ordered_dimensions=ordered_dimensions if ordered_dimensions else None,
+        exclude_dimensions=exclude_dimensions if exclude_dimensions else None,
+        subplot_width=merged.get("subplot_width", 3.5),
+        subplot_height=merged.get("subplot_height", 3.0),
+        auto_titles=not merged.get("no_auto_titles", False),
+        row_titles=not merged.get("no_auto_titles", False)
+        if merged.get("rows")
+        else False,
+        col_titles=not merged.get("no_auto_titles", False)
+        if merged.get("cols")
+        else False,
+        exterior_x_label=exterior_x_label,
+        exterior_y_label=exterior_y_label,
+    )
+
+
+def build_plot_config(config: CLIConfig, theme=None, **cli_overrides) -> PlotConfig:
+    """Build PlotConfig from CLI arguments and config file."""
+    merged = config.merge_with_cli_args(cli_overrides)
+
+    return PlotConfig(
+        layout=LayoutConfig(
+            rows=1,
+            cols=1,
+            tight_layout=True,
+            tight_layout_pad=1.0,
+        ),
+        legend=LegendConfig(strategy=merged.get("legend_strategy", "subplot")),
+        style=StyleConfig(theme=theme) if theme else None,
+    )
+
+
+def validate_dimensions_interactive(
+    data, faceting_config, allow_skip: bool = True
+) -> bool:
+    """Wrapper for interactive dimension validation with consistent messaging."""
+    click.echo("🔍 Validating dimensional configuration...")
+
+    if not interactive_dimension_validation(
+        data, faceting_config, allow_skip=allow_skip
+    ):
+        click.echo("❌ Aborted by user.")
+        return False
+
+    click.echo("✅ Dimensional validation passed.")
+    return True
+
+
+# Complete decorator for standard dimensional plotting CLIs
+def dimensional_plotting_cli(valid_dimensions: List[str]) -> Callable[[F], F]:
+    """Complete decorator that adds all standard dimensional plotting options."""
+
+    def decorator(f: F) -> F:
+        # Apply all option decorators in reverse order (Click requirement)
+        f = output_options()(f)
+        f = legend_options()(f)
+        f = layout_options()(f)
+        f = dimensional_control_options()(f)
+        f = common_faceting_options(valid_dimensions)(f)
+        f = config_option()(f)
+
+        return f
+
+    return decorator

--- a/src/dr_plotter/scripting/config_schema.py
+++ b/src/dr_plotter/scripting/config_schema.py
@@ -1,0 +1,119 @@
+"""
+Configuration schema and examples for dimensional plotting CLI.
+
+Provides structured YAML configuration support with validation.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Union
+from pathlib import Path
+import yaml
+
+# Example configuration that mirrors dr_plotter config objects
+EXAMPLE_CONFIG = {
+    "faceting": {
+        "rows": None,
+        "cols": None,
+        "rows_and_cols": "model_size",
+        "max_cols": 4,
+        "hue_by": "dataset",
+        "alpha_by": "seed",
+        "size_by": None,
+        "marker_by": None,
+        "style_by": None,
+        "fixed_dimensions": {"metric": "loss"},
+        "ordered_dimensions": {"model_size": ["1B", "7B", "30B", "70B", "180B"]},
+        "exclude_dimensions": {"dataset": ["deprecated_data"]},
+    },
+    "layout": {"subplot_width": 3.5, "subplot_height": 3.0, "auto_titles": True},
+    "legend": {"strategy": "grouped"},
+    "output": {"save_dir": "./plots", "pause": 5},
+}
+
+MINIMAL_CONFIG = {
+    "faceting": {
+        "rows_and_cols": "params",
+        "hue_by": "data",
+        "fixed_dimensions": {"metric": "pile-valppl"},
+    },
+    "legend": {"strategy": "figure"},
+}
+
+
+def write_example_config(path: Union[str, Path], minimal: bool = False) -> None:
+    """Write an example configuration file."""
+    config = MINIMAL_CONFIG if minimal else EXAMPLE_CONFIG
+
+    with open(path, "w") as f:
+        f.write("# dr_plotter dimensional plotting configuration\n")
+        f.write("# This file demonstrates the YAML config structure\n\n")
+        yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+
+
+def validate_config(config_data: Dict[str, Any]) -> List[str]:
+    """Validate configuration structure and return any errors."""
+    errors = []
+
+    # Check top-level sections
+    valid_sections = {"faceting", "layout", "legend", "output"}
+    for section in config_data:
+        if section not in valid_sections:
+            errors.append(f"Unknown configuration section: {section}")
+
+    # Validate faceting section
+    if "faceting" in config_data:
+        faceting = config_data["faceting"]
+
+        # Check for conflicting layout options
+        layout_options = [
+            faceting.get("rows"),
+            faceting.get("cols"),
+            faceting.get("rows_and_cols"),
+        ]
+        specified = [opt for opt in layout_options if opt is not None]
+        if len(specified) > 1:
+            errors.append(
+                "Cannot specify multiple layout options (rows, cols, rows_and_cols)"
+            )
+
+        # Validate dimensional control types
+        for dim_control in [
+            "fixed_dimensions",
+            "ordered_dimensions",
+            "exclude_dimensions",
+        ]:
+            if dim_control in faceting and not isinstance(faceting[dim_control], dict):
+                errors.append(f"{dim_control} must be a dictionary")
+
+    # Validate legend section
+    if "legend" in config_data:
+        legend = config_data["legend"]
+        if "strategy" in legend:
+            valid_strategies = ["subplot", "figure", "grouped", "none"]
+            if legend["strategy"] not in valid_strategies:
+                errors.append(
+                    f"Invalid legend strategy: {legend['strategy']}. Must be one of {valid_strategies}"
+                )
+
+    return errors
+
+
+def load_and_validate_config(config_path: Union[str, Path]) -> Dict[str, Any]:
+    """Load and validate a configuration file."""
+    try:
+        with open(config_path) as f:
+            config_data = yaml.safe_load(f)
+    except yaml.YAMLError as e:
+        raise ValueError(f"Invalid YAML in config file: {e}")
+    except FileNotFoundError:
+        raise ValueError(f"Config file not found: {config_path}")
+
+    errors = validate_config(config_data)
+    if errors:
+        error_msg = "Configuration validation errors:\n" + "\n".join(
+            f"  - {err}" for err in errors
+        )
+        raise ValueError(error_msg)
+
+    return config_data

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,38 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.1.8"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188 },
+]
+
+[[package]]
+name = "click"
+version = "8.2.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215 },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -274,6 +306,8 @@ name = "dr-plotter"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "matplotlib", version = "3.10.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -282,6 +316,7 @@ dependencies = [
     { name = "pandas" },
     { name = "pyarrow" },
     { name = "pydantic" },
+    { name = "pyyaml" },
     { name = "scikit-learn", version = "1.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "scikit-learn", version = "1.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -297,11 +332,13 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.0.0" },
     { name = "matplotlib", specifier = ">=3.9.4" },
     { name = "numpy", specifier = ">=2.0.2" },
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pyarrow", specifier = ">=21.0.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
+    { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "scikit-learn", specifier = ">=1.6.1" },
     { name = "scipy", specifier = ">=1.13.1" },
     { name = "seaborn", specifier = ">=0.13.2" },
@@ -1398,6 +1435,59 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225 },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/95/a3fac87cb7158e231b5a6012e438c647e1a87f09f8e0d123acec8ab8bf71/PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086", size = 184199 },
+    { url = "https://files.pythonhosted.org/packages/c7/7a/68bd47624dab8fd4afbfd3c48e3b79efe09098ae941de5b58abcbadff5cb/PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf", size = 171758 },
+    { url = "https://files.pythonhosted.org/packages/49/ee/14c54df452143b9ee9f0f29074d7ca5516a36edb0b4cc40c3f280131656f/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237", size = 718463 },
+    { url = "https://files.pythonhosted.org/packages/4d/61/de363a97476e766574650d742205be468921a7b532aa2499fcd886b62530/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b", size = 719280 },
+    { url = "https://files.pythonhosted.org/packages/6b/4e/1523cb902fd98355e2e9ea5e5eb237cbc5f3ad5f3075fa65087aa0ecb669/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed", size = 751239 },
+    { url = "https://files.pythonhosted.org/packages/b7/33/5504b3a9a4464893c32f118a9cc045190a91637b119a9c881da1cf6b7a72/PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180", size = 695802 },
+    { url = "https://files.pythonhosted.org/packages/5c/20/8347dcabd41ef3a3cdc4f7b7a2aff3d06598c8779faa189cdbf878b626a4/PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68", size = 720527 },
+    { url = "https://files.pythonhosted.org/packages/be/aa/5afe99233fb360d0ff37377145a949ae258aaab831bde4792b32650a4378/PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99", size = 144052 },
+    { url = "https://files.pythonhosted.org/packages/b5/84/0fa4b06f6d6c958d207620fc60005e241ecedceee58931bb20138e1e5776/PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e", size = 161774 },
+    { url = "https://files.pythonhosted.org/packages/f8/aa/7af4e81f7acba21a4c6be026da38fd2b872ca46226673c89a758ebdc4fd2/PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774", size = 184612 },
+    { url = "https://files.pythonhosted.org/packages/8b/62/b9faa998fd185f65c1371643678e4d58254add437edb764a08c5a98fb986/PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee", size = 172040 },
+    { url = "https://files.pythonhosted.org/packages/ad/0c/c804f5f922a9a6563bab712d8dcc70251e8af811fce4524d57c2c0fd49a4/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c", size = 736829 },
+    { url = "https://files.pythonhosted.org/packages/51/16/6af8d6a6b210c8e54f1406a6b9481febf9c64a3109c541567e35a49aa2e7/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317", size = 764167 },
+    { url = "https://files.pythonhosted.org/packages/75/e4/2c27590dfc9992f73aabbeb9241ae20220bd9452df27483b6e56d3975cc5/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85", size = 762952 },
+    { url = "https://files.pythonhosted.org/packages/9b/97/ecc1abf4a823f5ac61941a9c00fe501b02ac3ab0e373c3857f7d4b83e2b6/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4", size = 735301 },
+    { url = "https://files.pythonhosted.org/packages/45/73/0f49dacd6e82c9430e46f4a027baa4ca205e8b0a9dce1397f44edc23559d/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e", size = 756638 },
+    { url = "https://files.pythonhosted.org/packages/22/5f/956f0f9fc65223a58fbc14459bf34b4cc48dec52e00535c79b8db361aabd/PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5", size = 143850 },
+    { url = "https://files.pythonhosted.org/packages/ed/23/8da0bbe2ab9dcdd11f4f4557ccaf95c10b9811b13ecced089d43ce59c3c8/PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44", size = 161980 },
+    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873 },
+    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302 },
+    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154 },
+    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223 },
+    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542 },
+    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164 },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611 },
+    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591 },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338 },
+    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309 },
+    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679 },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428 },
+    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361 },
+    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523 },
+    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660 },
+    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597 },
+    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527 },
+    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446 },
+    { url = "https://files.pythonhosted.org/packages/65/d8/b7a1db13636d7fb7d4ff431593c510c8b8fca920ade06ca8ef20015493c5/PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d", size = 184777 },
+    { url = "https://files.pythonhosted.org/packages/0a/02/6ec546cd45143fdf9840b2c6be8d875116a64076218b61d68e12548e5839/PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f", size = 172318 },
+    { url = "https://files.pythonhosted.org/packages/0e/9a/8cc68be846c972bda34f6c2a93abb644fb2476f4dcc924d52175786932c9/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290", size = 720891 },
+    { url = "https://files.pythonhosted.org/packages/e9/6c/6e1b7f40181bc4805e2e07f4abc10a88ce4648e7e95ff1abe4ae4014a9b2/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12", size = 722614 },
+    { url = "https://files.pythonhosted.org/packages/3d/32/e7bd8535d22ea2874cef6a81021ba019474ace0d13a4819c2a4bce79bd6a/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19", size = 737360 },
+    { url = "https://files.pythonhosted.org/packages/d7/12/7322c1e30b9be969670b672573d45479edef72c9a0deac3bb2868f5d7469/PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e", size = 699006 },
+    { url = "https://files.pythonhosted.org/packages/82/72/04fcad41ca56491995076630c3ec1e834be241664c0c09a64c9a2589b507/PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725", size = 723577 },
+    { url = "https://files.pythonhosted.org/packages/ed/5e/46168b1f2757f1fcd442bc3029cd8767d88a98c9c05770d8b420948743bb/PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631", size = 144593 },
+    { url = "https://files.pythonhosted.org/packages/19/87/5124b1c1f2412bb95c59ec481eaf936cd32f0fe2a7b16b97b81c4c017a6a/PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8", size = 162312 },
 ]
 
 [[package]]


### PR DESCRIPTION
### TL;DR

Add YAML configuration support and CLI framework for dimensional plotting

### What changed?

- Added YAML configuration support with example files in `/configs/` directory
- Created a CLI framework in `dr_plotter.scripting` for building dimensional plotting applications
- Added a global `dr-plotter` command for creating plots from data files
- Moved `ExampleData` from examples to `dr_plotter.scripting` for reuse
- Updated all example scripts to use the new import path

### How to test?

```bash
# Use with demo script
uv run python scripts/plot_scaling_demo.py --config configs/example_config.yaml

# Use the global CLI command
dr-plotter data.parquet --rows-and-cols model --hue-by dataset

# Use in your own applications
from dr_plotter.scripting import CLIConfig
config = CLIConfig.from_yaml('configs/example_config.yaml')
```

### Why make this change?

This change makes dr_plotter more accessible by providing a standardized way to configure plots through YAML files instead of code. The CLI framework enables consistent command-line interfaces across applications that use dr_plotter, while the global `dr-plotter` command allows quick visualization of data files without writing code.